### PR TITLE
Avoid 2nd start of the simulation server

### DIFF
--- a/pc/device.c
+++ b/pc/device.c
@@ -54,7 +54,11 @@ void device_set_status(int status)
 
 int udp_server()
 {
-    int fd;
+    static bool run_already = false;
+    static int fd = -1;
+    if (run_already && fd >= 0) return fd;
+    run_already = true;
+
     if ( (fd = socket(AF_INET, SOCK_DGRAM, 0)) < 0 ) {
         perror( "socket failed" );
         return 1;


### PR DESCRIPTION
udp_server() is being called second time during the simulated run, which
fails due to trying to claim already used port. This patch adds cache to
the udp_server() result.

Example failing run:
```
$ ./main 
state file exists                                 
bind failed: Address already in use               
```

With patch the simulation starts as expected. The direct cause is probably in calling the `device_init()` more than one time - perhaps an issue worth to investigate further?

Environment: 
- Fedora 29
- g++ (GCC) 8.2.1 20181215 (Red Hat 8.2.1-6)

Edit: all tests pass