### PR TITLE
Make solotool complain if it's run with py2

### DIFF
--- a/tools/solotool.py
+++ b/tools/solotool.py
@@ -954,6 +954,10 @@ def main_mergehex():
 
 if __name__ == '__main__':
 
+    if sys.version_info[0] < 3:
+        print('Sorry, python3 is required.')
+        sys.exit(1)
+
     if len(sys.argv) < 2 or (len(sys.argv) == 2 and asked_for_help()):
         print('Diverse command line tool for working with Solo')
         print('usage: %s <command> [options] [-h]' % sys.argv[0])


### PR DESCRIPTION
Someone on the keybase chat ran solotool with py2 and it blew up. It worked as soon as they ran it with py3.  This way it will fail in a way that points to a solution.