### PR TITLE
Docker build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,5 @@ targets/efm32/EFM32_EFM32JG1B200F128GM32.hwconf
 targets/efm32/emlib/em_adc.c
 targets/efm32/emlib/em_assert.c
 targets/efm32/emlib/em_cmu.c
+
+builds/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,35 +1,69 @@
+# Step 1: build the firmware
 FROM debian:stretch-slim
 MAINTAINER SoloKeys <hello@solokeys.com>
 
-# get build requirements
 RUN apt-get update -qq
-RUN apt-get install -qq git make wget bzip2 >/dev/null
-
-# get Python3.7
-RUN wget -q https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-RUN bash ./Miniconda3-latest-Linux-x86_64.sh -b -p /tmp/conda
-RUN ln -s /tmp/conda/bin/python3 /usr/local/bin/python3
+RUN apt-get install -qq bzip2 git make wget >/dev/null
 
 # get ARM GCC
 RUN wget -q -O gcc.tar.bz2 https://developer.arm.com/-/media/Files/downloads/gnu-rm/8-2018q4/gcc-arm-none-eabi-8-2018-q4-major-linux.tar.bz2?revision=d830f9dd-cd4f-406d-8672-cca9210dd220?product=GNU%20Arm%20Embedded%20Toolchain,64-bit,,Linux,8-2018-q4-major
+#   from website
 RUN echo "f55f90d483ddb3bcf4dae5882c2094cd  gcc.tar.bz2" > gcc.md5
 RUN md5sum -c gcc.md5
+#   self-generated
+RUN echo "fb31fbdfe08406ece43eef5df623c0b2deb8b53e405e2c878300f7a1f303ee52  gcc.tar.bz2" > gcc.sha256
+RUN sha256sum -c gcc.sha256
 RUN tar -C /opt -xf gcc.tar.bz2
 
 # get Solo source code
 RUN git clone --recurse-submodules https://github.com/solokeys/solo
 
 # build Solo
-RUN cd solo && make env3
 ENV PREFIX=/opt/gcc-arm-none-eabi-8-2018-q4-major/bin/
-RUN . solo/env3/bin/activate && cd solo/targets/stm32l432 && \
-    make cbor && \
-    make build-hacker
+RUN cd solo/targets/stm32l432 && \
+    make cbor boot-no-sig clean all-hacker
 
-# would prefer `FROM scratch`, not sure how to copy firmware out though?
-FROM alpine
+
+# Step 2: combine the firmware
+FROM debian:stretch-slim
+MAINTAINER SoloKeys <hello@solokeys.com>
+
+RUN apt-get update -qq
+RUN apt-get install -qq bzip2 git make wget >/dev/null
+
+# get Python3.7
+RUN wget -q -O miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-4.5.12-Linux-x86_64.sh
+#   from website
+RUN echo "866ae9dff53ad0874e1d1a60b1ad1ef8  miniconda.sh" > miniconda.md5
+RUN md5sum -c miniconda.md5
+#   self-generated
+RUN echo "e5e5b4cd2a918e0e96b395534222773f7241dc59d776db1b9f7fedfcb489157a  miniconda.sh" > miniconda.sha256
+RUN sha256sum -c miniconda.sha256
+
+RUN bash ./miniconda.sh -b -p /opt/conda
+RUN ln -s /opt/conda/bin/python3 /usr/local/bin/python3
+
+# get Solo source code
+RUN git clone --recurse-submodules https://github.com/solokeys/solo
+
+# actually combine the two hex files
 COPY --from=0 /solo/targets/stm32l432/solo.elf .
 COPY --from=0 /solo/targets/stm32l432/solo.hex .
 COPY --from=0 /solo/targets/stm32l432/bootloader.elf .
 COPY --from=0 /solo/targets/stm32l432/bootloader.hex .
-COPY --from=0 /solo/targets/stm32l432/all.hex .
+
+RUN cd solo && make env3 && . env3/bin/activate && \
+    python3 tools/solotool.py mergehex /bootloader.hex /solo.hex /all.hex
+
+
+# Step 3: copy out firmware, assumes host volume mounted at /out
+FROM alpine
+MAINTAINER SoloKeys <hello@solokeys.com>
+
+COPY --from=1 /solo.elf .
+COPY --from=1 /solo.hex .
+COPY --from=1 /bootloader.elf .
+COPY --from=1 /bootloader.hex .
+COPY --from=1 /all.hex .
+
+CMD cp -v /solo.elf /solo.hex /bootloader.elf /bootloader.hex /all.hex /out

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+FROM debian:stretch-slim
+MAINTAINER SoloKeys <hello@solokeys.com>
+
+# get build requirements
+RUN apt-get update -qq
+RUN apt-get install -qq git make wget bzip2 >/dev/null
+
+# get Python3.7
+RUN wget -q https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+RUN bash ./Miniconda3-latest-Linux-x86_64.sh -b -p /tmp/conda
+RUN ln -s /tmp/conda/bin/python3 /usr/local/bin/python3
+
+# get ARM GCC
+RUN wget -q -O gcc.tar.bz2 https://developer.arm.com/-/media/Files/downloads/gnu-rm/8-2018q4/gcc-arm-none-eabi-8-2018-q4-major-linux.tar.bz2?revision=d830f9dd-cd4f-406d-8672-cca9210dd220?product=GNU%20Arm%20Embedded%20Toolchain,64-bit,,Linux,8-2018-q4-major
+RUN echo "f55f90d483ddb3bcf4dae5882c2094cd  gcc.tar.bz2" > gcc.md5
+RUN md5sum -c gcc.md5
+RUN tar -C /opt -xf gcc.tar.bz2
+
+# get Solo source code
+RUN git clone --recurse-submodules https://github.com/solokeys/solo
+
+# build Solo
+RUN cd solo && make env3
+ENV PREFIX=/opt/gcc-arm-none-eabi-8-2018-q4-major/bin/
+RUN . solo/env3/bin/activate && cd solo/targets/stm32l432 && \
+    make cbor && \
+    make build-hacker
+
+# Would prefer `FROM scratch`, not sure how to copy firmware out though?
+FROM alpine
+COPY --from=0 /solo/targets/stm32l432/solo.elf .
+COPY --from=0 /solo/targets/stm32l432/solo.hex .
+COPY --from=0 /solo/targets/stm32l432/bootloader.elf .
+COPY --from=0 /solo/targets/stm32l432/bootloader.hex .
+COPY --from=0 /solo/targets/stm32l432/all.hex .

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN . solo/env3/bin/activate && cd solo/targets/stm32l432 && \
     make cbor && \
     make build-hacker
 
-# Would prefer `FROM scratch`, not sure how to copy firmware out though?
+# would prefer `FROM scratch`, not sure how to copy firmware out though?
 FROM alpine
 COPY --from=0 /solo/targets/stm32l432/solo.elf .
 COPY --from=0 /solo/targets/stm32l432/solo.hex .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,10 @@
-# Step 1: build the firmware
 FROM debian:stretch-slim
 MAINTAINER SoloKeys <hello@solokeys.com>
 
 RUN apt-get update -qq
 RUN apt-get install -qq bzip2 git make wget >/dev/null
 
-# get ARM GCC
+# 1. ARM GCC: for compilation
 RUN wget -q -O gcc.tar.bz2 https://developer.arm.com/-/media/Files/downloads/gnu-rm/8-2018q4/gcc-arm-none-eabi-8-2018-q4-major-linux.tar.bz2?revision=d830f9dd-cd4f-406d-8672-cca9210dd220?product=GNU%20Arm%20Embedded%20Toolchain,64-bit,,Linux,8-2018-q4-major
 #   from website
 RUN echo "f55f90d483ddb3bcf4dae5882c2094cd  gcc.tar.bz2" > gcc.md5
@@ -15,23 +14,7 @@ RUN echo "fb31fbdfe08406ece43eef5df623c0b2deb8b53e405e2c878300f7a1f303ee52  gcc.
 RUN sha256sum -c gcc.sha256
 RUN tar -C /opt -xf gcc.tar.bz2
 
-# get Solo source code
-RUN git clone --recurse-submodules https://github.com/solokeys/solo
-
-# build Solo
-ENV PREFIX=/opt/gcc-arm-none-eabi-8-2018-q4-major/bin/
-RUN cd solo/targets/stm32l432 && \
-    make cbor boot-no-sig clean all-hacker
-
-
-# Step 2: combine the firmware
-FROM debian:stretch-slim
-MAINTAINER SoloKeys <hello@solokeys.com>
-
-RUN apt-get update -qq
-RUN apt-get install -qq bzip2 git make wget >/dev/null
-
-# get Python3.7
+# 2. Python3.7: for solotool (merging etc.)
 RUN wget -q -O miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-4.5.12-Linux-x86_64.sh
 #   from website
 RUN echo "866ae9dff53ad0874e1d1a60b1ad1ef8  miniconda.sh" > miniconda.md5
@@ -42,28 +25,8 @@ RUN sha256sum -c miniconda.sha256
 
 RUN bash ./miniconda.sh -b -p /opt/conda
 RUN ln -s /opt/conda/bin/python3 /usr/local/bin/python3
+RUN ln -s /opt/conda/bin/python3 /usr/local/bin/python
 
-# get Solo source code
-RUN git clone --recurse-submodules https://github.com/solokeys/solo
+# 3. Source code
+RUN git clone --recurse-submodules https://github.com/solokeys/solo /solo
 
-# actually combine the two hex files
-COPY --from=0 /solo/targets/stm32l432/solo.elf .
-COPY --from=0 /solo/targets/stm32l432/solo.hex .
-COPY --from=0 /solo/targets/stm32l432/bootloader.elf .
-COPY --from=0 /solo/targets/stm32l432/bootloader.hex .
-
-RUN cd solo && make env3 && . env3/bin/activate && \
-    python3 tools/solotool.py mergehex /bootloader.hex /solo.hex /all.hex
-
-
-# Step 3: copy out firmware, assumes host volume mounted at /out
-FROM alpine
-MAINTAINER SoloKeys <hello@solokeys.com>
-
-COPY --from=1 /solo.elf .
-COPY --from=1 /solo.hex .
-COPY --from=1 /bootloader.elf .
-COPY --from=1 /bootloader.hex .
-COPY --from=1 /all.hex .
-
-CMD cp -v /solo.elf /solo.hex /bootloader.elf /bootloader.hex /all.hex /out

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,12 @@ wink: venv
 fido2-test: venv
 	venv/bin/python tools/ctap_test.py
 
+DOCKER_IMAGE := "solokeys/solo-firmware:latest"
+docker-build:
+	docker build -t $(DOCKER_IMAGE) .
+	# docker build --no-cache -t $(DOCKER_IMAGE) .
+	docker run -rm -v$(PWD):/out $(DOCKER_IMAGE)
+
 CPPCHECK_FLAGS=--quiet --error-exitcode=2
 
 cppcheck:

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ CFLAGS += -DAES256=1 -DAPP_CONFIG=\"app.h\"
 
 name = main
 
-.PHONY: all $(LIBCBOR) black blackcheck cppcheck wink fido2-test clean full-clean travis test clean
+.PHONY: all $(LIBCBOR) black blackcheck cppcheck wink fido2-test clean full-clean travis test clean version
 all: main
 
 tinycbor/Makefile crypto/tiny-AES-c/aes.c:
@@ -41,6 +41,9 @@ cbor: $(LIBCBOR)
 
 $(LIBCBOR):
 	cd tinycbor/ && $(MAKE) clean && $(MAKE) -j8
+
+version:
+	@git describe
 
 test: venv
 	$(MAKE) clean
@@ -71,11 +74,11 @@ wink: venv
 fido2-test: venv
 	venv/bin/python tools/ctap_test.py
 
-DOCKER_IMAGE := "solokeys/solo-firmware:latest"
+DOCKER_IMAGE := "solokeys/solo-firmware:local"
+SOLO_VERSION := "master"
 docker-build:
 	docker build -t $(DOCKER_IMAGE) .
-	# docker build --no-cache -t $(DOCKER_IMAGE) .
-	docker run -rm -v$(PWD):/out $(DOCKER_IMAGE)
+	docker run --rm -v$(PWD)/builds:/builds -v$(PWD)/docker-build.sh:/build.sh $(DOCKER_IMAGE) /build.sh $(SOLO_VERSION)
 
 CPPCHECK_FLAGS=--quiet --error-exitcode=2
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Solo for Hacker is a special version of Solo that let you customize its firmware
 
 You can only buy Solo for Hacker at [solokeys.com](https://solokeys.com), as we don't sell it on Amazon and other places to avoid confusing customers. If you buy a Hacker, you can permanently lock it into a regular Solo, but viceversa you can NOT take a regular Solo and turn it a Hacker.
 
-If you have a Solo for Hacker, here's how you can load your own code on it. You can find more details, including how to permanently lock it, in our [documentation](https://docs.solokeys.io/solo/building/).
+If you have a Solo for Hacker, here's how you can load your own code on it. You can find more details, including how to permanently lock it, in our [documentation](https://docs.solokeys.io/solo/building/). We only support Python3.
 
 ```bash
 git clone --recurse-submodules https://github.com/solokeys/solo
@@ -43,13 +43,15 @@ cd solo
 
 cd targets/stm32l432
 make cbor
-make all-hacker
+make build-hacker
 cd ../..
 
 make venv
 source venv/bin/activate
 python tools/solotool.py program targets/stm32l432/solo.hex
 ```
+
+Alternatively, run `make docker-build` and use the firmware generated in `/tmp`.
 
 If you forgot the `--recurse-submodules` when cloning, simply `git submodule update --init --recursive`.
 

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -xe
+
+version=${1:-master}
+
+export PREFIX=/opt/gcc-arm-none-eabi-8-2018-q4-major/bin/
+
+cd /solo/targets/stm32l432
+git checkout ${version}
+version=$(git describe)
+make cbor
+make all-hacker
+
+cd /
+
+out_dir="builds"
+out_hex="solo-${version}.hex"
+out_sha2="solo-${version}.sha2"
+cp /solo/targets/stm32l432/solo.hex ${out_dir}/${out_hex}
+cd ${out_dir}
+sha256sum ${out_hex} > ${out_sha2}
+

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,5 +1,6 @@
 ecdsa
+fido2
 intelhex
 pyserial
-fido2
 pyusb
+wheel


### PR DESCRIPTION
A first step towards reproducible builds, answers https://github.com/solokeys/solo/issues/59 and Linux side of https://github.com/solokeys/solo/issues/19.

"It works on my machine", which is Linux.

Next steps towards reproducibility:
- lock down inputs
- (...[many fiddly details](https://reproducible-builds.org/docs/)...)
- sign builds (with some designated Solo Hacker attestation key)

We could start by adding a cronjob to Travis, to copy nightly builds generated by this PR's Dockerfile to [Bintray](https://bintray.com/solokeys), or as GitHub releases (I think this approach requires [a dance with force-updating tags](https://github.community/t5/How-to-use-Git-and-GitHub/Nightly-Builds-Latest-Branch-Releases/m-p/5000#M1621)).