### PR TITLE
Fix udev documentation

### DIFF
--- a/docs/solo/udev.md
+++ b/docs/solo/udev.md
@@ -65,8 +65,8 @@ udevadm trigger
 ## What about vendor and product ID for Solo?
 | Key | Vendor ID | Product ID |
 | --- | --- | --- |
-| Solo | 10c4 | 8acf |
-| U2F Zero | 0483 | a2ca |
+| Solo | 0483 | a2ca |
+| U2F Zero | 10c4 | 8acf |
 
 ## You got this all wrong, I can't believe it!
 Are you suffering from [us being wrong](https://xkcd.com/386/)? Please, send us a [pull request](https://github.com/solokeys/solo/pulls) and prove us wrong :D


### PR DESCRIPTION
The `vendorId` and `productId` of `Solo` were assigned to `U2F Zero` and vice versa.