### PR TITLE
Fix buffer overread in ctap_encode_der_sig()

### DIFF
--- a/fido2/ctap.h
+++ b/fido2/ctap.h
@@ -279,7 +279,7 @@ uint8_t ctap_request(uint8_t * pkt_raw, int length, CTAP_RESPONSE * resp);
 
 // Encodes R,S signature to 2 der sequence of two integers.  Sigder must be at least 72 bytes.
 // @return length of der signature
-int ctap_encode_der_sig(uint8_t * sigbuf, uint8_t * sigder);
+int ctap_encode_der_sig(uint8_t const * const in_sigbuf, uint8_t * const out_sigder);
 
 // Run ctap related power-up procedures (init pinToken, generate shared secret)
 void ctap_init();


### PR DESCRIPTION
Take into account leading zeroes in the size to copy, for both R and S
ingredients of the signature.
Issue was occuring only in cases, when there was a leading zero for the
S part.

Refactor ctap_encode_der_sig():
- add in_ and out_ prefixes to the function arguments
- mark pointers const
- clear out buffer

Tested via simulated device on:
- Fedora 29
- gcc (GCC) 8.2.1 20181215 (Red Hat 8.2.1-6)
- libasan 8.2.1 / 6.fc29
(same machine, as in the related issue description)
by running ctap_test() Python test in a loop for 20 minutes (dev's
counter 400k+). Earlier issue was occuring in first minutes.

Tested on Nucleo32 board, by running the ctap_test() 20 times.

Fixes https://github.com/solokeys/solo/issues/94
