### PR TITLE
Testing

### DIFF
--- a/fido2/ctap.c
+++ b/fido2/ctap.c
@@ -820,7 +820,7 @@ int ctap_filter_invalid_credentials(CTAP_getAssertion * GA)
                 printf1(TAG_GA, "RK %d is a rpId match!\r\n", i);
                 if (count == ALLOW_LIST_MAX_SIZE-1)
                 {
-                    printf2(TAG_ERR, "not enough ram allocated for matching RK's (%d)\r\n", count);
+                    printf2(TAG_ERR, "not enough ram allocated for matching RK's (%d).  Skipping.\r\n", count);
                     break;
                 }
                 GA->creds[count].type = PUB_KEY_CRED_PUB_KEY;

--- a/pc/device.c
+++ b/pc/device.c
@@ -502,8 +502,16 @@ uint32_t ctap_rk_size()
 
 void ctap_store_rk(int index, CTAP_residentKey * rk)
 {
-    memmove(RK_STORE.rks + index, rk, sizeof(CTAP_residentKey));
-    sync_rk();
+    if (index < RK_NUM)
+    {
+        memmove(RK_STORE.rks + index, rk, sizeof(CTAP_residentKey));
+        sync_rk();
+    }
+    else
+    {
+        printf1(TAG_ERR,"Out of bounds for store_rk\r\n");
+    }
+
 }
 
 
@@ -514,8 +522,15 @@ void ctap_load_rk(int index, CTAP_residentKey * rk)
 
 void ctap_overwrite_rk(int index, CTAP_residentKey * rk)
 {
-    memmove(RK_STORE.rks + index, rk, sizeof(CTAP_residentKey));
-    sync_rk();
+    if (index < RK_NUM)
+    {
+        memmove(RK_STORE.rks + index, rk, sizeof(CTAP_residentKey));
+        sync_rk();
+    }
+    else
+    {
+        printf1(TAG_ERR,"Out of bounds for store_rk\r\n");
+    }
 }
 
 void device_wink()

--- a/targets/stm32l432/src/device.c
+++ b/targets/stm32l432/src/device.c
@@ -596,7 +596,7 @@ void ctap_overwrite_rk(int index,CTAP_residentKey * rk)
 
         memmove(tmppage + (sizeof(CTAP_residentKey) * index) % PAGE_SIZE, rk, sizeof(CTAP_residentKey));
         flash_erase_page(page);
-        flash_write(flash_addr(page), tmppage, ((sizeof(CTAP_residentKey) * (index + 1)) % PAGE_SIZE) );
+        flash_write(flash_addr(page), tmppage, PAGE_SIZE);
     }
     else
     {

--- a/tools/ctap_test.py
+++ b/tools/ctap_test.py
@@ -660,7 +660,7 @@ class Tester:
         user0 = {"id": b"first one", "name": "single User"}
 
         users = [
-            {"id": b"user" + os.urandom(16), "name": "AB User"} for i in range(0, 2)
+            {"id": b"user" + os.urandom(16), "name": "AB User"} for i in range(0, 10)
         ]
         challenge = "Y2hhbGxlbmdl"
         PIN = None
@@ -834,17 +834,32 @@ def test_find_brute_force():
 
 
 if __name__ == "__main__":
-    if len(sys.argv) > 1 and sys.argv[1] == "sim":
+    if len(sys.argv) < 2:
+        print("Usage: %s [sim] <[u2f]|[fido2]|[rk]|[hid]|[ping]>")
+        sys.exit(0)
+
+    if "sim" in sys.argv:
         print("Using UDP backend.")
         force_udp_backend()
 
     t = Tester()
     t.find_device()
-    # t.test_hid()
-    # t.test_long_ping()
-    # t.test_fido2()
-    t.test_u2f()
-    # t.test_rk()
+
+    if "hid" in sys.argv:
+        t.test_hid()
+
+    if "ping" in sys.argv:
+        t.test_long_ping()
+
+    if "u2f" in sys.argv:
+        t.test_u2f()
+
+    if "fido2" in sys.argv:
+        t.test_fido2()
+
+    if "rk" in sys.argv:
+        t.test_rk()
+
     # t.test_responses()
     # test_find_brute_force()
     # t.test_fido2_simple()

--- a/tools/ctap_test.py
+++ b/tools/ctap_test.py
@@ -746,7 +746,6 @@ class Tester:
     def test_rk(self,):
         creds = []
         rp = {"id": self.host, "name": "ExaRP"}
-        user0 = {"id": b"first one", "name": "single User"}
 
         users = [
             {"id": b"user" + os.urandom(16), "name": "Username%d" % i}
@@ -761,7 +760,7 @@ class Tester:
         print("registering 1 user with RK")
         t1 = time.time() * 1000
         attest, data = self.client.make_credential(
-            rp, user0, challenge, pin=PIN, exclude_list=[], rk=True
+            rp, users[-1], challenge, pin=PIN, exclude_list=[], rk=True
         )
         t2 = time.time() * 1000
         VerifyAttestation(attest, data)
@@ -780,7 +779,7 @@ class Tester:
         print(assertions[0], client_data)
 
         print("registering %d users with RK" % len(users))
-        for i in range(0, len(users)):
+        for i in range(0, len(users) - 1):
             t1 = time.time() * 1000
             attest, data = self.client.make_credential(
                 rp, users[i], challenge, pin=PIN, exclude_list=[], rk=True
@@ -796,6 +795,9 @@ class Tester:
             rp["id"], challenge, pin=PIN
         )
         t2 = time.time() * 1000
+
+        print("Got %d assertions for %d users" % (len(assertions), len(users)))
+        assert len(assertions) == len(users)
 
         for x, y in zip(assertions, creds):
             x.verify(client_data.hash, y.public_key)
@@ -819,7 +821,7 @@ class Tester:
         )
         t2 = time.time() * 1000
         print("Assertions: %d, users: %d" % (len(assertions), len(users)))
-        assert len(assertions) == len(users) + 1
+        assert len(assertions) == len(users)
         for x, y in zip(assertions, creds):
             x.verify(client_data.hash, y.public_key)
 


### PR DESCRIPTION
This adds better testing support from Python, in particular for U2F.  It checks for the issues we previous ran into (counter endianness and return error codes).

I also implemented the functions for resident key support for PC builds.  Full coverage can be tested by running:

```
make
./main
```

```
python .\tools\ctap_test.py sim hid fido2 rk u2f ping
```

Or leave out "sim" to test an actual token.