### PR TITLE
Do not signal "AT modem" for ACM-CDC serial

### DIFF
--- a/targets/stm32l432/lib/usbd/usbd_composite.c
+++ b/targets/stm32l432/lib/usbd/usbd_composite.c
@@ -110,7 +110,7 @@ __ALIGN_BEGIN uint8_t COMPOSITE_CDC_HID_DESCRIPTOR[COMPOSITE_CDC_HID_DESCRIPTOR_
   0x03,   /* bNumEndpoints: 3 endpoints used */
   0x02,   /* bInterfaceClass: Communication Interface Class */
   0x02,   /* bInterfaceSubClass: Abstract Control Model */
-  0x01,   /* bInterfaceProtocol: Common AT commands */
+  0x00,   /* bInterfaceProtocol: Common AT commands */
   0x00,   /* iInterface: */
 
   /*Header Functional Descriptor*/

--- a/udev/Makefile
+++ b/udev/Makefile
@@ -10,6 +10,8 @@
 
 setup: install activate
 legacy-setup: install-legacy activate
+
+# Symlinks can be setup, we don't officially supply any
 # symlinks: install-symlinks activate
 
 RULES_PATH=/etc/udev/rules.d
@@ -31,6 +33,14 @@ install-legacy:
 # if ModemManager is running with "strict" filter policy.
 # Debian Buster for instance does this.
 # One solution is to run ModemManager with "paranoid" filter policy.
-paranoid-modemmanager: dropin-paranoid-modemmanager activate
+paranoid-modemmanager: dropin-paranoid-modemmanager restart-modemmanager
 dropin-paranoid-modemmanager:
 	test -f /usr/sbin/ModemManager && sudo cp ModemManager-override.conf /etc/systemd/system/ModemManager.service.d/override.conf
+
+strict-modemmanager: dropin-strict-modemmanager restart-modemmanager
+dropin-strict-modemmanager:
+	sudo rm -f /etc/systemd/system/ModemManager.service.d/override.conf
+
+restart-modemmanager:
+	sudo systemctl daemon-reload
+	sudo systemctl restart ModemManager.service

--- a/udev/Makefile
+++ b/udev/Makefile
@@ -26,3 +26,11 @@ install-legacy:
 
 # install-symlinks:
 # 	sudo cp $(PWD)/71-solokeys-symlinks.rules ${RULES_PATH}/71-solokeys-symlinks.rules
+
+# The ID_MM_DEVICE_IGNORE tag in our udev rules are ignored
+# if ModemManager is running with "strict" filter policy.
+# Debian Buster for instance does this.
+# One solution is to run ModemManager with "paranoid" filter policy.
+paranoid-modemmanager: dropin-paranoid-modemmanager activate
+dropin-paranoid-modemmanager:
+	test -f /usr/sbin/ModemManager && sudo cp ModemManager-override.conf /etc/systemd/system/ModemManager.service.d/override.conf

--- a/udev/Makefile
+++ b/udev/Makefile
@@ -28,19 +28,3 @@ install-legacy:
 
 # install-symlinks:
 # 	sudo cp $(PWD)/71-solokeys-symlinks.rules ${RULES_PATH}/71-solokeys-symlinks.rules
-
-# The ID_MM_DEVICE_IGNORE tag in our udev rules are ignored
-# if ModemManager is running with "strict" filter policy.
-# Debian Buster for instance does this.
-# One solution is to run ModemManager with "paranoid" filter policy.
-paranoid-modemmanager: dropin-paranoid-modemmanager restart-modemmanager
-dropin-paranoid-modemmanager:
-	test -f /usr/sbin/ModemManager && sudo cp ModemManager-override.conf /etc/systemd/system/ModemManager.service.d/override.conf
-
-strict-modemmanager: dropin-strict-modemmanager restart-modemmanager
-dropin-strict-modemmanager:
-	sudo rm -f /etc/systemd/system/ModemManager.service.d/override.conf
-
-restart-modemmanager:
-	sudo systemctl daemon-reload
-	sudo systemctl restart ModemManager.service

--- a/udev/ModemManager-override.conf
+++ b/udev/ModemManager-override.conf
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=/usr/sbin/ModemManager --filter-policy=paranoid

--- a/udev/ModemManager-override.conf
+++ b/udev/ModemManager-override.conf
@@ -1,3 +1,0 @@
-[Service]
-ExecStart=
-ExecStart=/usr/sbin/ModemManager --filter-policy=paranoid


### PR DESCRIPTION
Improves https://github.com/solokeys/solo/issues/62, but the drop-in file is a little brittle.

The real solution would be to include our VID/PID pair in ModemManager upstream.
https://bugs.freedesktop.org/show_bug.cgi?id=85007#c4

~~http://cgit.freedesktop.org/ModemManager/ModemManager seems to be down right now though.~~ https://gitlab.freedesktop.org/mobile-broadband/ModemManager/issues/111