### PR TITLE
Hmac-secret

### DIFF
--- a/fido2/ctap.c
+++ b/fido2/ctap.c
@@ -354,7 +354,7 @@ static int ctap_make_extensions(CTAP_extensions * ext, uint8_t * ext_encoder_buf
         else
         {
             printf1(TAG_CTAP, "saltAuth is invalid\r\n");
-            return CTAP1_ERR_OTHER;
+            return CTAP2_ERR_EXTENSION_FIRST;
         }
 
         // Generate credRandom

--- a/fido2/ctap.c
+++ b/fido2/ctap.c
@@ -69,6 +69,8 @@ uint8_t verify_pin_auth(uint8_t * pinAuth, uint8_t * clientDataHash)
 
 }
 
+
+
 uint8_t ctap_get_info(CborEncoder * encoder)
 {
     int ret;
@@ -77,21 +79,32 @@ uint8_t ctap_get_info(CborEncoder * encoder)
     CborEncoder options;
     CborEncoder pins;
 
-    const int number_of_versions = 2;
-
-    ret = cbor_encoder_create_map(encoder, &map, 5);
+    ret = cbor_encoder_create_map(encoder, &map, 6);
     check_ret(ret);
     {
 
         ret = cbor_encode_uint(&map, RESP_versions);     //  versions key
         check_ret(ret);
         {
-            ret = cbor_encoder_create_array(&map, &array, number_of_versions);
+            ret = cbor_encoder_create_array(&map, &array, 2);
             check_ret(ret);
             {
                 ret = cbor_encode_text_stringz(&array, "U2F_V2");
                 check_ret(ret);
                 ret = cbor_encode_text_stringz(&array, "FIDO_2_0");
+                check_ret(ret);
+            }
+            ret = cbor_encoder_close_container(&map, &array);
+            check_ret(ret);
+        }
+
+        ret = cbor_encode_uint(&map, RESP_extensions);
+        check_ret(ret);
+        {
+            ret = cbor_encoder_create_array(&map, &array, 1);
+            check_ret(ret);
+            {
+                ret = cbor_encode_text_stringz(&array, "hmac-secret");
                 check_ret(ret);
             }
             ret = cbor_encoder_close_container(&map, &array);

--- a/fido2/ctap.c
+++ b/fido2/ctap.c
@@ -386,7 +386,6 @@ static int ctap_make_extensions(CTAP_extensions * ext, uint8_t * ext_encoder_buf
         cbor_encoder_init(&extensions, ext_encoder_buf, *ext_encoder_buf_size, 0);
         printf1(TAG_GREEN, "have %d bytes for Extenstions encoder\r\n",*ext_encoder_buf_size);
         CborEncoder ext_map;
-        CborEncoder hmac_secret_map;
         ret = cbor_encoder_create_map(&extensions, &ext_map, 1);
         check_ret(ret);
         {
@@ -1088,7 +1087,7 @@ uint8_t ctap_get_next_assertion(CborEncoder * encoder)
 uint8_t ctap_get_assertion(CborEncoder * encoder, uint8_t * request, int length)
 {
     CTAP_getAssertion GA;
-    uint8_t auth_data_buf[sizeof(CTAP_authDataHeader) + 128];
+    uint8_t auth_data_buf[sizeof(CTAP_authDataHeader) + 100];
     int ret = ctap_parse_get_assertion(&GA,request,length);
 
     if (ret != 0)

--- a/fido2/ctap.c
+++ b/fido2/ctap.c
@@ -383,16 +383,11 @@ static int ctap_make_extensions(CTAP_extensions * ext, uint8_t * ext_encoder_buf
         crypto_aes256_encrypt(output, ext->hmac_secret.saltLen);
 
         // output
-        cbor_encoder_init(&extensions, ext_encoder_buf, *ext_encoder_buf_size, 0);
         printf1(TAG_GREEN, "have %d bytes for Extenstions encoder\r\n",*ext_encoder_buf_size);
-        CborEncoder ext_map;
-        ret = cbor_encoder_create_map(&extensions, &ext_map, 1);
-        check_ret(ret);
+        cbor_encoder_init(&extensions, ext_encoder_buf, *ext_encoder_buf_size, 0);
         {
-            ret = cbor_encode_int(&ext_map,GA_extensions);
-            check_ret(ret);
             CborEncoder hmac_secret_map;
-            ret = cbor_encoder_create_map(&ext_map, &hmac_secret_map, 1);
+            ret = cbor_encoder_create_map(&extensions, &hmac_secret_map, 1);
             check_ret(ret);
             {
                 ret = cbor_encode_text_stringz(&hmac_secret_map, "hmac-secret");
@@ -401,11 +396,9 @@ static int ctap_make_extensions(CTAP_extensions * ext, uint8_t * ext_encoder_buf
                 ret = cbor_encode_byte_string(&hmac_secret_map, output, ext->hmac_secret.saltLen);
                 check_ret(ret);
             }
-            ret = cbor_encoder_close_container(&ext_map, &hmac_secret_map);
+            ret = cbor_encoder_close_container(&extensions, &hmac_secret_map);
             check_ret(ret);
         }
-        ret = cbor_encoder_close_container(&extensions, &ext_map);
-        check_ret(ret);
         *ext_encoder_buf_size = cbor_encoder_get_buffer_size(&extensions, ext_encoder_buf);
     }
     else
@@ -1071,7 +1064,7 @@ uint8_t ctap_get_next_assertion(CborEncoder * encoder)
 uint8_t ctap_get_assertion(CborEncoder * encoder, uint8_t * request, int length)
 {
     CTAP_getAssertion GA;
-    uint8_t auth_data_buf[sizeof(CTAP_authDataHeader) + 100];
+    uint8_t auth_data_buf[sizeof(CTAP_authDataHeader) + 80];
     int ret = ctap_parse_get_assertion(&GA,request,length);
 
     if (ret != 0)

--- a/fido2/ctap.h
+++ b/fido2/ctap.h
@@ -183,6 +183,11 @@ struct rpId
 
 typedef struct
 {
+    uint8_t hmac_secret;
+} CTAP_extensions;
+
+typedef struct
+{
     uint32_t paramsParsed;
     uint8_t clientDataHash[CLIENT_DATA_HASH_SIZE];
     struct rpId rp;
@@ -201,6 +206,7 @@ typedef struct
     uint8_t pinAuth[16];
     uint8_t pinAuthPresent;
     int pinProtocol;
+    CTAP_extensions extensions;
 
 } CTAP_makeCredential;
 

--- a/fido2/ctap.h
+++ b/fido2/ctap.h
@@ -54,6 +54,10 @@
 #define CP_getKeyAgreement        0x07
 #define CP_getRetries             0x08
 
+#define EXT_HMAC_SECRET_COSE_KEY    0x01
+#define EXT_HMAC_SECRET_SALT_ENC    0x02
+#define EXT_HMAC_SECRET_SALT_AUTH   0x03
+
 #define RESP_versions               0x1
 #define RESP_extensions             0x2
 #define RESP_aaguid                 0x3
@@ -183,7 +187,26 @@ struct rpId
 
 typedef struct
 {
-    uint8_t hmac_secret;
+    struct{
+        uint8_t x[32];
+        uint8_t y[32];
+    } pubkey;
+
+    int kty;
+    int crv;
+} COSE_key;
+
+typedef struct
+{
+    uint8_t saltEnc[64];
+    uint8_t saltAuth[32];
+    COSE_key keyAgreement;
+} CTAP_hmac_secret;
+
+typedef struct
+{
+    uint8_t hmac_secret_present;
+    CTAP_hmac_secret hmac_secret;
 } CTAP_extensions;
 
 typedef struct
@@ -236,22 +259,16 @@ typedef struct
 
     CTAP_credentialDescriptor creds[ALLOW_LIST_MAX_SIZE];
     uint8_t allowListPresent;
+
+    CTAP_extensions extensions;
+
 } CTAP_getAssertion;
 
 typedef struct
 {
     int pinProtocol;
     int subCommand;
-    struct
-    {
-        struct{
-            uint8_t x[32];
-            uint8_t y[32];
-        } pubkey;
-
-        int kty;
-        int crv;
-    } keyAgreement;
+    COSE_key keyAgreement;
     uint8_t keyAgreementPresent;
     uint8_t pinAuth[16];
     uint8_t pinAuthPresent;

--- a/fido2/ctap.h
+++ b/fido2/ctap.h
@@ -215,18 +215,23 @@ typedef struct
 
 typedef struct
 {
+    CTAP_userEntity user;
+    uint8_t publicKeyCredentialType;
+    int32_t COSEAlgorithmIdentifier;
+    uint8_t rk;
+} CTAP_credInfo;
+
+typedef struct
+{
     uint32_t paramsParsed;
     uint8_t clientDataHash[CLIENT_DATA_HASH_SIZE];
     struct rpId rp;
-    CTAP_userEntity user;
 
-    uint8_t publicKeyCredentialType;
-    int32_t COSEAlgorithmIdentifier;
+    CTAP_credInfo credInfo;
 
     CborValue excludeList;
     size_t excludeListSize;
 
-    uint8_t rk;
     uint8_t uv;
     uint8_t up;
 

--- a/fido2/ctap.h
+++ b/fido2/ctap.h
@@ -149,9 +149,13 @@ struct Credential {
     CredentialId id;
     CTAP_userEntity user;
 };
-
 typedef struct Credential CTAP_residentKey;
 
+typedef struct
+{
+    uint8_t type;
+    struct Credential credential;
+} CTAP_credentialDescriptor;
 
 typedef struct
 {
@@ -205,6 +209,7 @@ typedef struct
     uint8_t saltEnc[64];
     uint8_t saltAuth[32];
     COSE_key keyAgreement;
+    struct Credential * credential;
 } CTAP_hmac_secret;
 
 typedef struct
@@ -242,11 +247,7 @@ typedef struct
 
 } CTAP_makeCredential;
 
-typedef struct
-{
-    uint8_t type;
-    struct Credential credential;
-} CTAP_credentialDescriptor;
+
 
 typedef struct
 {

--- a/fido2/ctap.h
+++ b/fido2/ctap.h
@@ -58,6 +58,9 @@
 #define EXT_HMAC_SECRET_SALT_ENC    0x02
 #define EXT_HMAC_SECRET_SALT_AUTH   0x03
 
+#define EXT_HMAC_SECRET_REQUESTED   0x01
+#define EXT_HMAC_SECRET_PARSED      0x02
+
 #define RESP_versions               0x1
 #define RESP_extensions             0x2
 #define RESP_aaguid                 0x3
@@ -198,6 +201,7 @@ typedef struct
 
 typedef struct
 {
+    uint8_t salt_len;
     uint8_t saltEnc[64];
     uint8_t saltAuth[32];
     COSE_key keyAgreement;

--- a/fido2/ctap.h
+++ b/fido2/ctap.h
@@ -201,7 +201,7 @@ typedef struct
 
 typedef struct
 {
-    uint8_t salt_len;
+    uint8_t saltLen;
     uint8_t saltEnc[64];
     uint8_t saltAuth[32];
     COSE_key keyAgreement;

--- a/fido2/ctap_parse.c
+++ b/fido2/ctap_parse.c
@@ -601,11 +601,11 @@ uint8_t ctap_parse_hmac_secret(CborValue * val, CTAP_hmac_secret * hs)
             case EXT_HMAC_SECRET_SALT_ENC:
                 salt_len = 64;
                 ret = cbor_value_copy_byte_string(&map, hs->saltEnc, &salt_len, NULL);
-                check_ret(ret);
-                if (salt_len != 32 && salt_len != 64)
+                if ((salt_len != 32 && salt_len != 64) || ret == CborErrorOutOfMemory)
                 {
                     return CTAP1_ERR_INVALID_LENGTH;
                 }
+                check_ret(ret);
                 hs->saltLen = salt_len;
                 parsed_count++;
             break;

--- a/fido2/ctap_parse.c
+++ b/fido2/ctap_parse.c
@@ -635,9 +635,9 @@ uint8_t ctap_parse_extensions(CborValue * val, CTAP_extensions * ext)
 {
     CborValue map;
     size_t sz, map_length;
-    uint8_t key[16];
-    uint8_t ret;
-    int i;
+    char key[16];
+    int ret;
+    unsigned int i;
     bool b;
 
     if (cbor_value_get_type(val) != CborMapType)

--- a/fido2/ctap_parse.c
+++ b/fido2/ctap_parse.c
@@ -128,14 +128,14 @@ uint8_t parse_user(CTAP_makeCredential * MC, CborValue * val)
             }
 
             sz = USER_ID_MAX_SIZE;
-            ret = cbor_value_copy_byte_string(&map, MC->user.id, &sz, NULL);
+            ret = cbor_value_copy_byte_string(&map, MC->credInfo.user.id, &sz, NULL);
             if (ret == CborErrorOutOfMemory)
             {
                 printf2(TAG_ERR,"Error, USER_ID is too large\n");
                 return CTAP2_ERR_LIMIT_EXCEEDED;
             }
-            MC->user.id_size = sz;
-            printf1(TAG_GREEN,"parsed id_size: %d\r\n", MC->user.id_size);
+            MC->credInfo.user.id_size = sz;
+            printf1(TAG_GREEN,"parsed id_size: %d\r\n", MC->credInfo.user.id_size);
             check_ret(ret);
         }
         else if (strcmp((const char *)key, "name") == 0)
@@ -146,12 +146,12 @@ uint8_t parse_user(CTAP_makeCredential * MC, CborValue * val)
                 return CTAP2_ERR_INVALID_CBOR_TYPE;
             }
             sz = USER_NAME_LIMIT;
-            ret = cbor_value_copy_text_string(&map, (char *)MC->user.name, &sz, NULL);
+            ret = cbor_value_copy_text_string(&map, (char *)MC->credInfo.user.name, &sz, NULL);
             if (ret != CborErrorOutOfMemory)
             {   // Just truncate the name it's okay
                 check_ret(ret);
             }
-            MC->user.name[USER_NAME_LIMIT - 1] = 0;
+            MC->credInfo.user.name[USER_NAME_LIMIT - 1] = 0;
         }
         else if (strcmp((const char *)key, "displayName") == 0)
         {
@@ -161,12 +161,12 @@ uint8_t parse_user(CTAP_makeCredential * MC, CborValue * val)
                 return CTAP2_ERR_INVALID_CBOR_TYPE;
             }
             sz = DISPLAY_NAME_LIMIT;
-            ret = cbor_value_copy_text_string(&map, (char *)MC->user.displayName, &sz, NULL);
+            ret = cbor_value_copy_text_string(&map, (char *)MC->credInfo.user.displayName, &sz, NULL);
             if (ret != CborErrorOutOfMemory)
             {   // Just truncate the name it's okay
                 check_ret(ret);
             }
-            MC->user.displayName[DISPLAY_NAME_LIMIT - 1] = 0;
+            MC->credInfo.user.displayName[DISPLAY_NAME_LIMIT - 1] = 0;
         }
         else if (strcmp((const char *)key, "icon") == 0)
         {
@@ -176,12 +176,12 @@ uint8_t parse_user(CTAP_makeCredential * MC, CborValue * val)
                 return CTAP2_ERR_INVALID_CBOR_TYPE;
             }
             sz = ICON_LIMIT;
-            ret = cbor_value_copy_text_string(&map, (char *)MC->user.icon, &sz, NULL);
+            ret = cbor_value_copy_text_string(&map, (char *)MC->credInfo.user.icon, &sz, NULL);
             if (ret != CborErrorOutOfMemory)
             {   // Just truncate the name it's okay
                 check_ret(ret);
             }
-            MC->user.icon[ICON_LIMIT - 1] = 0;
+            MC->credInfo.user.icon[ICON_LIMIT - 1] = 0;
 
         }
         else
@@ -305,8 +305,8 @@ uint8_t parse_pub_key_cred_params(CTAP_makeCredential * MC, CborValue * val)
         {
             if (pub_key_cred_param_supported(cred_type, alg_type) == CREDENTIAL_IS_SUPPORTED)
             {
-                MC->publicKeyCredentialType = cred_type;
-                MC->COSEAlgorithmIdentifier = alg_type;
+                MC->credInfo.publicKeyCredentialType = cred_type;
+                MC->credInfo.COSEAlgorithmIdentifier = alg_type;
                 MC->paramsParsed |= PARAM_pubKeyCredParams;
                 return 0;
             }
@@ -779,8 +779,8 @@ uint8_t ctap_parse_make_credential(CTAP_makeCredential * MC, CborEncoder * encod
 
                 ret = parse_user(MC, &map);
 
-                printf1(TAG_MC,"  ID: "); dump_hex1(TAG_MC, MC->user.id, MC->user.id_size);
-                printf1(TAG_MC,"  name: %s\n", MC->user.name);
+                printf1(TAG_MC,"  ID: "); dump_hex1(TAG_MC, MC->credInfo.user.id, MC->credInfo.user.id_size);
+                printf1(TAG_MC,"  name: %s\n", MC->credInfo.user.name);
 
                 break;
             case MC_pubKeyCredParams:
@@ -788,8 +788,8 @@ uint8_t ctap_parse_make_credential(CTAP_makeCredential * MC, CborEncoder * encod
 
                 ret = parse_pub_key_cred_params(MC, &map);
 
-                printf1(TAG_MC,"  cred_type: 0x%02x\n", MC->publicKeyCredentialType);
-                printf1(TAG_MC,"  alg_type: %d\n", MC->COSEAlgorithmIdentifier);
+                printf1(TAG_MC,"  cred_type: 0x%02x\n", MC->credInfo.publicKeyCredentialType);
+                printf1(TAG_MC,"  alg_type: %d\n", MC->credInfo.COSEAlgorithmIdentifier);
 
                 break;
             case MC_excludeList:
@@ -819,7 +819,7 @@ uint8_t ctap_parse_make_credential(CTAP_makeCredential * MC, CborEncoder * encod
 
             case MC_options:
                 printf1(TAG_MC,"CTAP_options\n");
-                ret = parse_options(&map, &MC->rk, &MC->uv, &MC->up);
+                ret = parse_options(&map, &MC->credInfo.rk, &MC->uv, &MC->up);
                 check_retr(ret);
                 break;
             case MC_pinAuth:

--- a/fido2/ctap_parse.c
+++ b/fido2/ctap_parse.c
@@ -606,7 +606,7 @@ uint8_t ctap_parse_hmac_secret(CborValue * val, CTAP_hmac_secret * hs)
                 {
                     return CTAP1_ERR_INVALID_LENGTH;
                 }
-                hs->salt_len = salt_len;
+                hs->saltLen = salt_len;
                 parsed_count++;
             break;
             case EXT_HMAC_SECRET_SALT_AUTH:

--- a/fido2/ctap_parse.h
+++ b/fido2/ctap_parse.h
@@ -30,7 +30,7 @@ uint8_t parse_rp(struct rpId * rp, CborValue * val);
 uint8_t parse_options(CborValue * val, uint8_t * rk, uint8_t * uv, uint8_t * up);
 
 uint8_t parse_allow_list(CTAP_getAssertion * GA, CborValue * it);
-uint8_t parse_cose_key(CborValue * it, uint8_t * x, uint8_t * y, int * kty, int * crv);
+uint8_t parse_cose_key(CborValue * it, COSE_key * cose);
 
 
 uint8_t ctap_parse_make_credential(CTAP_makeCredential * MC, CborEncoder * encoder, uint8_t * request, int length);

--- a/targets/stm32l432/build/application.mk
+++ b/targets/stm32l432/build/application.mk
@@ -46,7 +46,7 @@ DEFINES = -DDEBUG_LEVEL=$(DEBUG) -D$(CHIP) -DAES256=1  -DUSE_FULL_LL_DRIVER -DAP
 
 CFLAGS=$(INC) -c $(DEFINES)   -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers -fdata-sections -ffunction-sections \
 	-fomit-frame-pointer $(HW) -g $(VERSION_FLAGS)
-LDFLAGS_LIB=$(HW) $(SEARCH) -specs=nano.specs  -specs=nosys.specs  -Wl,--gc-sections -u _printf_float -lnosys
+LDFLAGS_LIB=$(HW) $(SEARCH) -specs=nano.specs  -specs=nosys.specs  -Wl,--gc-sections -lnosys
 LDFLAGS=$(HW) $(LDFLAGS_LIB) -T$(LDSCRIPT) -Wl,-Map=$(TARGET).map,--cref -Wl,-Bstatic -ltinycbor
 
 ECC_CFLAGS = $(CFLAGS) -DuECC_PLATFORM=5 -DuECC_OPTIMIZATION_LEVEL=4 -DuECC_SQUARE_FUNC=1 -DuECC_SUPPORT_COMPRESSED_POINT=0

--- a/targets/stm32l432/src/redirect.c
+++ b/targets/stm32l432/src/redirect.c
@@ -39,7 +39,7 @@ int _write (int fd, const void *buf, unsigned long int len)
 	// logbuflen += len;
 
 	// Send out USB serial
-	CDC_Transmit_FS(buf, len);
+	CDC_Transmit_FS(data, len);
 	// if (res == USBD_OK)
 	// 	logbuflen = 0;
 #endif

--- a/tools/ctap_test.py
+++ b/tools/ctap_test.py
@@ -803,6 +803,11 @@ class Tester:
             other={"extensions": {"hmac-secret": True}, "options": {"rk": True}},
         )
 
+        with Test("Check 'hmac-secret' is set to true in auth_data extensions"):
+            assert reg.auth_data.extensions
+            assert "hmac-secret" in reg.auth_data.extensions
+            assert reg.auth_data.extensions["hmac-secret"] == True
+
         with Test("Get shared secret"):
             key_agreement, shared_secret = (
                 self.client.pin_protocol._init_shared_secret()

--- a/tools/ctap_test.py
+++ b/tools/ctap_test.py
@@ -1786,7 +1786,8 @@ class Tester:
                 entropy += sc.get_rng()
 
         with Test("Test entropy is close to perfect"):
-            assert shannon_entropy(entropy) > 7.98
+            sum = shannon_entropy(entropy)
+            assert sum > 7.98
         print("Entropy is %.5f bits per byte." % sum)
 
         with Test("Test Solo version command"):

--- a/tools/ctap_test.py
+++ b/tools/ctap_test.py
@@ -2004,8 +2004,19 @@ def test_find_brute_force():
 
 
 if __name__ == "__main__":
+    tests = (
+        "solo",
+        "u2f",
+        "fido2",
+        "fido2-ext",
+        "rk",
+        "hid",
+        "ping",
+        "bootloader",
+    )
+
     if len(sys.argv) < 2:
-        print("Usage: %s [sim] <[u2f]|[fido2]|[rk]|[hid]|[ping]>")
+        print(f"Usage: {sys.argv[0]} [sim] <{'|'.join(sorted(tests))}>")
         sys.exit(0)
 
     t = Tester()

--- a/tools/ctap_test.py
+++ b/tools/ctap_test.py
@@ -787,7 +787,7 @@ class Tester:
         salt1 = b"\x5a" * 32
         salt2 = b"\x96" * 32
 
-        self.testReset()
+        # self.testReset()
 
         with Test("Get info has hmac-secret"):
             info = self.ctap.get_info()
@@ -841,20 +841,20 @@ class Tester:
             ):
                 ext = auth.auth_data.extensions
                 assert ext
-                assert "hmac-secret" in ext[4]
-                assert type(ext[4]["hmac-secret"]) == type(b"")
-                assert len(ext[4]["hmac-secret"]) == len(salt_list) * 32
+                assert "hmac-secret" in ext
+                assert type(ext["hmac-secret"]) == type(b"")
+                assert len(ext["hmac-secret"]) == len(salt_list) * 32
 
             with Test("Check that shannon_entropy of hmac-secret is good"):
                 ext = auth.auth_data.extensions
                 dec = cipher.decryptor()
-                key = dec.update(ext[4]["hmac-secret"]) + dec.finalize()
+                key = dec.update(ext["hmac-secret"]) + dec.finalize()
 
                 if len(salt_list) == 1:
-                    assert shannon_entropy(ext[4]["hmac-secret"]) > 4.6
+                    assert shannon_entropy(ext["hmac-secret"]) > 4.6
                     assert shannon_entropy(key) > 4.6
                 if len(salt_list) == 2:
-                    assert shannon_entropy(ext[4]["hmac-secret"]) > 5.6
+                    assert shannon_entropy(ext["hmac-secret"]) > 5.6
                     assert shannon_entropy(key) > 5.6
 
     def test_fido2_other(self,):

--- a/tools/ctap_test.py
+++ b/tools/ctap_test.py
@@ -2004,16 +2004,7 @@ def test_find_brute_force():
 
 
 if __name__ == "__main__":
-    tests = (
-        "solo",
-        "u2f",
-        "fido2",
-        "fido2-ext",
-        "rk",
-        "hid",
-        "ping",
-        "bootloader",
-    )
+    tests = ("solo", "u2f", "fido2", "fido2-ext", "rk", "hid", "ping", "bootloader")
 
     if len(sys.argv) < 2:
         print(f"Usage: {sys.argv[0]} [sim] <{'|'.join(sorted(tests))}>")

--- a/tools/ctap_test.py
+++ b/tools/ctap_test.py
@@ -1799,6 +1799,11 @@ class Tester:
             except ApduError:
                 pass
 
+        sc.exchange = sc.exchange_fido2
+        with Test("Test Solo version and random commands with fido2 layer"):
+            assert len(sc.solo_version()) == 3
+            sc.get_rng()
+
     def test_bootloader(self,):
         sc = SoloClient()
         sc.find_device(self.dev)


### PR DESCRIPTION
This adds the hmac-secret extension to Solo's CTAP implementation.

I haven't been able to find a service to use it with.  Apparently it's a requirement for Windows 10 log in, but I haven't been able to set up a security key with Windows yet.  

I tested by implementing `hmac-secret` tests in `ctap_test.py fido2-ext`, and making sure those work with Yubikey 5, which has `hmac-secret` implemented.  Then testing `ctap_test.py fido2-ext` works with Solo.