### PR TITLE
Fix buffer overrun and use correct size for random u32

### DIFF
--- a/targets/stm32l432/src/rng.c
+++ b/targets/stm32l432/src/rng.c
@@ -17,7 +17,7 @@ int __errno = 0;
 
 void rng_get_bytes(uint8_t * dst, size_t sz)
 {
-    uint8_t r[8];
+    uint8_t r[4];
     unsigned int i,j;
     for (i = 0; i < sz; i += 4)
     {
@@ -33,7 +33,7 @@ void rng_get_bytes(uint8_t * dst, size_t sz)
 
         for (j = 0; j < 4; j++)
         {
-            if ((i + j) > sz)
+            if ((i + j) >= sz)
             {
                 return;
             }


### PR DESCRIPTION
I think `get_rng_bytes` writes one byte too many if `sz` is not a multiple of 4.