### PR TITLE
include markdown-include mkdocs dependency

### DIFF
--- a/docs/solo/documenting.md
+++ b/docs/solo/documenting.md
@@ -3,7 +3,7 @@ Documentation of the `master` branch is deployed to Netlify automatically.
 To host or develop locally:
 
 ```
-pip install mkdocs mkdocs-material
+pip install mkdocs mkdocs-material markdown-include
 ```
 
 `mkdocs serve` and visit [localhost:8000](http://localhost:8000).


### PR DESCRIPTION
To avoid this error:
```
[ernie@eahimac2 solo[master*]]$ mkdocs serve
INFO    -  Building documentation...
ERROR   -  Config value: 'markdown_extensions'. Error: Failed loading extension "markdown_include.include".

Aborted with 1 Configuration Errors!
[ernie@eahimac2 solo[master*]]$
```