### PR TITLE
Fix cbor

### DIFF
--- a/fido2/ctap.c
+++ b/fido2/ctap.c
@@ -123,13 +123,6 @@ uint8_t ctap_get_info(CborEncoder * encoder)
             ret = cbor_encoder_create_map(&map, &options,4);
             check_ret(ret);
             {
-                ret = cbor_encode_text_string(&options, "plat", 4);
-                check_ret(ret);
-                {
-                    ret = cbor_encode_boolean(&options, 0);     // Not attached to platform
-                    check_ret(ret);
-                }
-
                 ret = cbor_encode_text_string(&options, "rk", 2);
                 check_ret(ret);
                 {
@@ -153,6 +146,15 @@ uint8_t ctap_get_info(CborEncoder * encoder)
                 //     ret = cbor_encode_boolean(&options, 0);
                 //     check_ret(ret);
                 // }
+
+                ret = cbor_encode_text_string(&options, "plat", 4);
+                check_ret(ret);
+                {
+                    ret = cbor_encode_boolean(&options, 0);     // Not attached to platform
+                    check_ret(ret);
+                }
+
+
                 ret = cbor_encode_text_string(&options, "clientPin", 9);
                 check_ret(ret);
                 {

--- a/tools/testing/tests/fido2.py
+++ b/tools/testing/tests/fido2.py
@@ -2,7 +2,6 @@ from __future__ import print_function, absolute_import, unicode_literals
 import time
 from random import randint
 import array
-import struct
 from functools import cmp_to_key
 
 from fido2 import cbor

--- a/tools/testing/tests/fido2.py
+++ b/tools/testing/tests/fido2.py
@@ -85,16 +85,13 @@ def TestCborKeysSorted(cbor_obj):
         l = cbor_obj
 
     l_sorted = sorted(l[:], key=cmp_to_key(cmp_cbor_keys))
-    print(l)
-    print(l_sorted)
+
     for i in range(len(l)):
 
         if not isinstance(l[i], (str, int)):
             raise ValueError(f"Cbor map key {l[i]} must be int or str for CTAP2")
 
         if l[i] != l_sorted[i]:
-            print("sorted", l_sorted)
-            print("real", l)
             raise ValueError(f"Cbor map item {i}: {l[i]} is out of order")
 
     return l
@@ -136,7 +133,20 @@ class FIDO2Tests(Tester):
             "baa",
             "bbb",
         ]
-        TestCborKeysSorted(cbor_key_list_sorted)
+        with Test("Self test CBOR sorting"):
+            TestCborKeysSorted(cbor_key_list_sorted)
+
+        with Test("Self test CBOR sorting integers", catch=ValueError):
+            TestCborKeysSorted([1, 0])
+
+        with Test("Self test CBOR sorting major type", catch=ValueError):
+            TestCborKeysSorted([-1, 0])
+
+        with Test("Self test CBOR sorting strings", catch=ValueError):
+            TestCborKeysSorted(["bb", "a"])
+
+        with Test("Self test CBOR sorting same length strings", catch=ValueError):
+            TestCborKeysSorted(["ab", "aa"])
 
     def run(self,):
         self.test_fido2()

--- a/tools/testing/tests/tester.py
+++ b/tools/testing/tests/tester.py
@@ -28,14 +28,21 @@ class Packet(object):
 
 
 class Test:
-    def __init__(self, msg):
+    def __init__(self, msg, catch=None):
         self.msg = msg
+        self.catch = catch
 
     def __enter__(self,):
         print(self.msg)
 
     def __exit__(self, a, b, c):
-        print("Pass")
+        if self.catch is None:
+            print("Pass")
+        elif isinstance(b, self.catch):
+            print("Pass")
+            return b
+        else:
+            raise RuntimeError(f"Expected exception {self.catch} did not occur.")
 
 
 class Tester:


### PR DESCRIPTION
Should fix #170.  Most of the CBOR maps encoded by Solo were not ordered in any particular way, so some platforms may fail to parse them since [they are supposed to be ordered](https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#ctap2-canonical-cbor-encoding-form). 

Also adds to python tests to check parsed CBOR maps to be in correct order.  Thanks to @agl for reporting.