### PR TITLE
Fix u2f on fido2

### DIFF
--- a/fido2/ctap.c
+++ b/fido2/ctap.c
@@ -1202,8 +1202,6 @@ uint8_t ctap_get_assertion(CborEncoder * encoder, uint8_t * request, int length)
 #ifdef ENABLE_U2F_EXTENSIONS
     if ( is_extension_request((uint8_t*)&GA.creds[validCredCount - 1].credential.id, sizeof(CredentialId)) )
     {
-        ret = cbor_encode_int(&map,RESP_authData);  // 2
-        check_ret(ret);
         memset(auth_data_buf,0,sizeof(CTAP_authDataHeader));
         auth_data_buf_sz = sizeof(CTAP_authDataHeader);
     }

--- a/fido2/ctap.h
+++ b/fido2/ctap.h
@@ -112,6 +112,7 @@
 #define CREDENTIAL_ENC_SIZE         176  // pad to multiple of 16 bytes
 
 #define PUB_KEY_CRED_PUB_KEY        0x01
+#define PUB_KEY_CRED_CTAP1          0x41
 #define PUB_KEY_CRED_UNKNOWN        0x3F
 
 #define CREDENTIAL_IS_SUPPORTED     1

--- a/fido2/u2f.h
+++ b/fido2/u2f.h
@@ -103,6 +103,7 @@ void u2f_request(struct u2f_request_apdu* req, CTAP_RESPONSE * resp);
 // @len data length
 void u2f_request_nfc(uint8_t * req, int len, CTAP_RESPONSE * resp);
 
+int8_t u2f_authenticate_credential(struct u2f_key_handle * kh, uint8_t * appid);
 
 int8_t u2f_response_writeback(const uint8_t * buf, uint16_t len);
 void u2f_reset_response();

--- a/targets/stm32l432/src/redirect.c
+++ b/targets/stm32l432/src/redirect.c
@@ -27,7 +27,7 @@ void _putchar(char c)
 int _write (int fd, const void *buf, unsigned long int len)
 {
     uint8_t * data = (uint8_t *) buf;
-#if DEBUG_LEVEL>1
+#if DEBUG_LEVEL>0
 	// static uint8_t logbuf[1000] = {0};
 	// static int logbuflen = 0;
 	// if (logbuflen + len > sizeof(logbuf)) {

--- a/tools/testing/tests/fido2.py
+++ b/tools/testing/tests/fido2.py
@@ -909,10 +909,6 @@ class FIDO2Tests(Tester):
             auth.verify(cdh, credential_data.public_key)
             assert auth.credential["id"] == reg.key_handle
 
-        import sys
-
-        sys.exit(1)
-
     def test_rk(self, pin_code=None):
 
         pin_auth = None


### PR DESCRIPTION
If a user registers using U2F, and then later authenticates on a browser that only uses FIDO2, it won't work since Solo's CTAP2 and CTAP1 have different key handles/ids, and Solo CTAP2 doesn't attempt to use a CTAP1 key handle.

This update adds support for CTAP1 key handles in CTAP2, so the above scenario will work.  Tests included.  Tested it works by registering with U2F on Chrome, updating key, and then authenticating with FIDO2.