### PR TITLE
No usbhid_init if NFC-powered?

### DIFF
--- a/targets/stm32l432/src/device.c
+++ b/targets/stm32l432/src/device.c
@@ -111,7 +111,7 @@ void device_init()
 {
 
     hw_init(LOW_FREQUENCY);
-    isLowFreq = 0;
+    isLowFreq = 1;
 
     haveNFC = nfc_init();
 


### PR DESCRIPTION
Not 100% sure, but I think the intention is not to start USBHID if we're NFC-powered?