### PR TITLE
Fix minor typo in comment

### DIFF
--- a/targets/stm32l432/lib/usbd/usbd_hid.c
+++ b/targets/stm32l432/lib/usbd/usbd_hid.c
@@ -309,7 +309,7 @@ static uint8_t  USBD_HID_Init (USBD_HandleTypeDef *pdev, uint8_t cfgidx)
 }
 
 /**
-  * @brief  USBD_HID_Init
+  * @brief  USBD_HID_DeInit
   *         DeInitialize the HID layer
   * @param  pdev: device instance
   * @param  cfgidx: Configuration index


### PR DESCRIPTION
'USBD_HID_DeInit' is written as 'USBD_HID_Init'; likely a copy-paste
error. This patch should fix it.