### PR TITLE
limit length of wLength

### DIFF
--- a/targets/stm32l432/lib/usbd/usbd_hid.c
+++ b/targets/stm32l432/lib/usbd/usbd_hid.c
@@ -342,6 +342,7 @@ static uint8_t  USBD_HID_Setup (USBD_HandleTypeDef *pdev,
   uint8_t *pbuf = NULL;
   uint16_t status_info = 0U;
   USBD_StatusTypeDef ret = USBD_OK;
+  req->wLength = req->wLength & 0x7f;
 
   switch (req->bmRequest & USB_REQ_TYPE_MASK)
   {
@@ -386,6 +387,7 @@ static uint8_t  USBD_HID_Setup (USBD_HandleTypeDef *pdev,
       break;
 
     case USB_REQ_GET_DESCRIPTOR:
+      req->wLength = req->wLength & 0x7f;
       if(req->wValue >> 8 == HID_REPORT_DESC)
       {
         len = MIN(HID_FIDO_REPORT_DESC_SIZE , req->wLength);


### PR DESCRIPTION
As demonstrated by @colinoflynn, the memory of Solo can be dumped with fault injection.  A physical glitch is inserted at the right time to cause an effective instruction skip, and cause all of SRAM to get read out for a USB request.

This is a quick fix to limit the user supplied length value to 128 bytes and make it harder to skip with fault injection.