### PR TITLE
cache button press for 2s

### DIFF
--- a/targets/stm32l432/build/common.mk
+++ b/targets/stm32l432/build/common.mk
@@ -6,7 +6,7 @@ AR=$(PREFIX)arm-none-eabi-ar
 DRIVER_LIBS := lib/stm32l4xx_hal_pcd.c lib/stm32l4xx_hal_pcd_ex.c lib/stm32l4xx_ll_gpio.c  \
        lib/stm32l4xx_ll_rcc.c lib/stm32l4xx_ll_rng.c lib/stm32l4xx_ll_tim.c  \
 	   lib/stm32l4xx_ll_usb.c lib/stm32l4xx_ll_utils.c lib/stm32l4xx_ll_pwr.c \
-	   lib/stm32l4xx_ll_usart.c lib/stm32l4xx_ll_spi.c
+	   lib/stm32l4xx_ll_usart.c lib/stm32l4xx_ll_spi.c lib/stm32l4xx_ll_exti.c
 
 USB_LIB := lib/usbd/usbd_cdc.c lib/usbd/usbd_cdc_if.c lib/usbd/usbd_composite.c \
 	   lib/usbd/usbd_conf.c lib/usbd/usbd_core.c lib/usbd/usbd_ioreq.c \

--- a/targets/stm32l432/lib/stm32l4xx_ll_exti.c
+++ b/targets/stm32l432/lib/stm32l4xx_ll_exti.c
@@ -1,0 +1,290 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_ll_exti.c
+  * @author  MCD Application Team
+  * @brief   EXTI LL module driver.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) 2017 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under BSD 3-Clause license,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/BSD-3-Clause
+  *
+  ******************************************************************************
+  */
+#if defined(USE_FULL_LL_DRIVER)
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx_ll_exti.h"
+#ifdef  USE_FULL_ASSERT
+#include "stm32_assert.h"
+#else
+#define assert_param(expr) ((void)0U)
+#endif
+
+/** @addtogroup STM32L4xx_LL_Driver
+  * @{
+  */
+
+#if defined (EXTI)
+
+/** @defgroup EXTI_LL EXTI
+  * @{
+  */
+
+/* Private types -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private constants ---------------------------------------------------------*/
+/* Private macros ------------------------------------------------------------*/
+/** @addtogroup EXTI_LL_Private_Macros
+  * @{
+  */
+
+#define IS_LL_EXTI_LINE_0_31(__VALUE__)              (((__VALUE__) & ~LL_EXTI_LINE_ALL_0_31) == 0x00000000U)
+#define IS_LL_EXTI_LINE_32_63(__VALUE__)             (((__VALUE__) & ~LL_EXTI_LINE_ALL_32_63) == 0x00000000U)
+
+#define IS_LL_EXTI_MODE(__VALUE__)                   (((__VALUE__) == LL_EXTI_MODE_IT)            \
+                                                   || ((__VALUE__) == LL_EXTI_MODE_EVENT)         \
+                                                   || ((__VALUE__) == LL_EXTI_MODE_IT_EVENT))
+
+
+#define IS_LL_EXTI_TRIGGER(__VALUE__)                (((__VALUE__) == LL_EXTI_TRIGGER_NONE)       \
+                                                   || ((__VALUE__) == LL_EXTI_TRIGGER_RISING)     \
+                                                   || ((__VALUE__) == LL_EXTI_TRIGGER_FALLING)    \
+                                                   || ((__VALUE__) == LL_EXTI_TRIGGER_RISING_FALLING))
+
+/**
+  * @}
+  */
+
+/* Private function prototypes -----------------------------------------------*/
+
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup EXTI_LL_Exported_Functions
+  * @{
+  */
+
+/** @addtogroup EXTI_LL_EF_Init
+  * @{
+  */
+
+/**
+  * @brief  De-initialize the EXTI registers to their default reset values.
+  * @retval An ErrorStatus enumeration value:
+  *          - 0x00: EXTI registers are de-initialized
+  */
+uint32_t LL_EXTI_DeInit(void)
+{
+  /* Interrupt mask register set to default reset values */
+  LL_EXTI_WriteReg(IMR1,   0xFF820000U);
+  /* Event mask register set to default reset values */
+  LL_EXTI_WriteReg(EMR1,   0x00000000U);
+  /* Rising Trigger selection register set to default reset values */
+  LL_EXTI_WriteReg(RTSR1,  0x00000000U);
+  /* Falling Trigger selection register set to default reset values */
+  LL_EXTI_WriteReg(FTSR1,  0x00000000U);
+  /* Software interrupt event register set to default reset values */
+  LL_EXTI_WriteReg(SWIER1, 0x00000000U);
+  /* Pending register clear */
+  LL_EXTI_WriteReg(PR1,    0x007DFFFFU);
+
+  /* Interrupt mask register 2 set to default reset values */
+#if defined(LL_EXTI_LINE_40)
+  LL_EXTI_WriteReg(IMR2,        0x00000187U);
+#else
+  LL_EXTI_WriteReg(IMR2,        0x00000087U);
+#endif
+  /* Event mask register 2 set to default reset values */
+  LL_EXTI_WriteReg(EMR2,        0x00000000U);
+  /* Rising Trigger selection register 2 set to default reset values */
+  LL_EXTI_WriteReg(RTSR2,       0x00000000U);
+  /* Falling Trigger selection register 2 set to default reset values */
+  LL_EXTI_WriteReg(FTSR2,       0x00000000U);
+  /* Software interrupt event register 2 set to default reset values */
+  LL_EXTI_WriteReg(SWIER2,      0x00000000U);
+  /* Pending register 2 clear */
+  LL_EXTI_WriteReg(PR2,         0x00000078U);
+
+  return 0x00u;
+}
+
+/**
+  * @brief  Initialize the EXTI registers according to the specified parameters in EXTI_InitStruct.
+  * @param  EXTI_InitStruct pointer to a @ref LL_EXTI_InitTypeDef structure.
+  * @retval An ErrorStatus enumeration value:
+  *          - 0x00: EXTI registers are initialized
+  *          - any other calue : wrong configuration
+  */
+uint32_t LL_EXTI_Init(LL_EXTI_InitTypeDef *EXTI_InitStruct)
+{
+  uint32_t status = 0x00u;
+
+  /* Check the parameters */
+  assert_param(IS_LL_EXTI_LINE_0_31(EXTI_InitStruct->Line_0_31));
+  assert_param(IS_LL_EXTI_LINE_32_63(EXTI_InitStruct->Line_32_63));
+  assert_param(IS_FUNCTIONAL_STATE(EXTI_InitStruct->LineCommand));
+  assert_param(IS_LL_EXTI_MODE(EXTI_InitStruct->Mode));
+
+  /* ENABLE LineCommand */
+  if (EXTI_InitStruct->LineCommand != DISABLE)
+  {
+    assert_param(IS_LL_EXTI_TRIGGER(EXTI_InitStruct->Trigger));
+
+    /* Configure EXTI Lines in range from 0 to 31 */
+    if (EXTI_InitStruct->Line_0_31 != LL_EXTI_LINE_NONE)
+    {
+      switch (EXTI_InitStruct->Mode)
+      {
+        case LL_EXTI_MODE_IT:
+          /* First Disable Event on provided Lines */
+          LL_EXTI_DisableEvent_0_31(EXTI_InitStruct->Line_0_31);
+          /* Then Enable IT on provided Lines */
+          LL_EXTI_EnableIT_0_31(EXTI_InitStruct->Line_0_31);
+          break;
+        case LL_EXTI_MODE_EVENT:
+          /* First Disable IT on provided Lines */
+          LL_EXTI_DisableIT_0_31(EXTI_InitStruct->Line_0_31);
+          /* Then Enable Event on provided Lines */
+          LL_EXTI_EnableEvent_0_31(EXTI_InitStruct->Line_0_31);
+          break;
+        case LL_EXTI_MODE_IT_EVENT:
+          /* Directly Enable IT & Event on provided Lines */
+          LL_EXTI_EnableIT_0_31(EXTI_InitStruct->Line_0_31);
+          LL_EXTI_EnableEvent_0_31(EXTI_InitStruct->Line_0_31);
+          break;
+        default:
+          status = 0x01u;
+          break;
+      }
+      if (EXTI_InitStruct->Trigger != LL_EXTI_TRIGGER_NONE)
+      {
+        switch (EXTI_InitStruct->Trigger)
+        {
+          case LL_EXTI_TRIGGER_RISING:
+            /* First Disable Falling Trigger on provided Lines */
+            LL_EXTI_DisableFallingTrig_0_31(EXTI_InitStruct->Line_0_31);
+            /* Then Enable Rising Trigger on provided Lines */
+            LL_EXTI_EnableRisingTrig_0_31(EXTI_InitStruct->Line_0_31);
+            break;
+          case LL_EXTI_TRIGGER_FALLING:
+            /* First Disable Rising Trigger on provided Lines */
+            LL_EXTI_DisableRisingTrig_0_31(EXTI_InitStruct->Line_0_31);
+            /* Then Enable Falling Trigger on provided Lines */
+            LL_EXTI_EnableFallingTrig_0_31(EXTI_InitStruct->Line_0_31);
+            break;
+          case LL_EXTI_TRIGGER_RISING_FALLING:
+            LL_EXTI_EnableRisingTrig_0_31(EXTI_InitStruct->Line_0_31);
+            LL_EXTI_EnableFallingTrig_0_31(EXTI_InitStruct->Line_0_31);
+            break;
+          default:
+            status |= 0x02u;
+            break;
+        }
+      }
+    }
+    /* Configure EXTI Lines in range from 32 to 63 */
+    if (EXTI_InitStruct->Line_32_63 != LL_EXTI_LINE_NONE)
+    {
+      switch (EXTI_InitStruct->Mode)
+      {
+        case LL_EXTI_MODE_IT:
+          /* First Disable Event on provided Lines */
+          LL_EXTI_DisableEvent_32_63(EXTI_InitStruct->Line_32_63);
+          /* Then Enable IT on provided Lines */
+          LL_EXTI_EnableIT_32_63(EXTI_InitStruct->Line_32_63);
+          break;
+        case LL_EXTI_MODE_EVENT:
+          /* First Disable IT on provided Lines */
+          LL_EXTI_DisableIT_32_63(EXTI_InitStruct->Line_32_63);
+          /* Then Enable Event on provided Lines */
+          LL_EXTI_EnableEvent_32_63(EXTI_InitStruct->Line_32_63);
+          break;
+        case LL_EXTI_MODE_IT_EVENT:
+          /* Directly Enable IT & Event on provided Lines */
+          LL_EXTI_EnableIT_32_63(EXTI_InitStruct->Line_32_63);
+          LL_EXTI_EnableEvent_32_63(EXTI_InitStruct->Line_32_63);
+          break;
+        default:
+          status |= 0x04u;
+          break;
+      }
+      if (EXTI_InitStruct->Trigger != LL_EXTI_TRIGGER_NONE)
+      {
+        switch (EXTI_InitStruct->Trigger)
+        {
+          case LL_EXTI_TRIGGER_RISING:
+            /* First Disable Falling Trigger on provided Lines */
+            LL_EXTI_DisableFallingTrig_32_63(EXTI_InitStruct->Line_32_63);
+            /* Then Enable IT on provided Lines */
+            LL_EXTI_EnableRisingTrig_32_63(EXTI_InitStruct->Line_32_63);
+            break;
+          case LL_EXTI_TRIGGER_FALLING:
+            /* First Disable Rising Trigger on provided Lines */
+            LL_EXTI_DisableRisingTrig_32_63(EXTI_InitStruct->Line_32_63);
+            /* Then Enable Falling Trigger on provided Lines */
+            LL_EXTI_EnableFallingTrig_32_63(EXTI_InitStruct->Line_32_63);
+            break;
+          case LL_EXTI_TRIGGER_RISING_FALLING:
+            LL_EXTI_EnableRisingTrig_32_63(EXTI_InitStruct->Line_32_63);
+            LL_EXTI_EnableFallingTrig_32_63(EXTI_InitStruct->Line_32_63);
+            break;
+          default:
+            status = ERROR;
+            break;
+        }
+      }
+    }
+  }
+  /* DISABLE LineCommand */
+  else
+  {
+    /* De-configure EXTI Lines in range from 0 to 31 */
+    LL_EXTI_DisableIT_0_31(EXTI_InitStruct->Line_0_31);
+    LL_EXTI_DisableEvent_0_31(EXTI_InitStruct->Line_0_31);
+    /* De-configure EXTI Lines in range from 32 to 63 */
+    LL_EXTI_DisableIT_32_63(EXTI_InitStruct->Line_32_63);
+    LL_EXTI_DisableEvent_32_63(EXTI_InitStruct->Line_32_63);
+  }
+
+  return status;
+}
+
+/**
+  * @brief  Set each @ref LL_EXTI_InitTypeDef field to default value.
+  * @param  EXTI_InitStruct Pointer to a @ref LL_EXTI_InitTypeDef structure.
+  * @retval None
+  */
+void LL_EXTI_StructInit(LL_EXTI_InitTypeDef *EXTI_InitStruct)
+{
+  EXTI_InitStruct->Line_0_31      = LL_EXTI_LINE_NONE;
+  EXTI_InitStruct->Line_32_63     = LL_EXTI_LINE_NONE;
+  EXTI_InitStruct->LineCommand    = DISABLE;
+  EXTI_InitStruct->Mode           = LL_EXTI_MODE_IT;
+  EXTI_InitStruct->Trigger        = LL_EXTI_TRIGGER_FALLING;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* defined (EXTI) */
+
+/**
+  * @}
+  */
+
+#endif /* USE_FULL_LL_DRIVER */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/targets/stm32l432/lib/stm32l4xx_ll_exti.h
+++ b/targets/stm32l432/lib/stm32l4xx_ll_exti.h
@@ -1,0 +1,1361 @@
+/**
+  ******************************************************************************
+  * @file    stm32l4xx_ll_exti.h
+  * @author  MCD Application Team
+  * @brief   Header file of EXTI LL module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; Copyright (c) 2017 STMicroelectronics.
+  * All rights reserved.</center></h2>
+  *
+  * This software component is licensed by ST under BSD 3-Clause license,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/BSD-3-Clause
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __STM32L4xx_LL_EXTI_H
+#define __STM32L4xx_LL_EXTI_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32l4xx.h"
+
+/** @addtogroup STM32L4xx_LL_Driver
+  * @{
+  */
+
+#if defined (EXTI)
+
+/** @defgroup EXTI_LL EXTI
+  * @{
+  */
+
+/* Private types -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private constants ---------------------------------------------------------*/
+/* Private Macros ------------------------------------------------------------*/
+#if defined(USE_FULL_LL_DRIVER)
+/** @defgroup EXTI_LL_Private_Macros EXTI Private Macros
+  * @{
+  */
+/**
+  * @}
+  */
+#endif /*USE_FULL_LL_DRIVER*/
+/* Exported types ------------------------------------------------------------*/
+#if defined(USE_FULL_LL_DRIVER)
+/** @defgroup EXTI_LL_ES_INIT EXTI Exported Init structure
+  * @{
+  */
+typedef struct
+{
+
+  uint32_t Line_0_31;           /*!< Specifies the EXTI lines to be enabled or disabled for Lines in range 0 to 31
+                                     This parameter can be any combination of @ref EXTI_LL_EC_LINE */
+
+  uint32_t Line_32_63;          /*!< Specifies the EXTI lines to be enabled or disabled for Lines in range 32 to 63
+                                     This parameter can be any combination of @ref EXTI_LL_EC_LINE */
+
+  FunctionalState LineCommand;  /*!< Specifies the new state of the selected EXTI lines.
+                                     This parameter can be set either to ENABLE or DISABLE */
+
+  uint8_t Mode;                 /*!< Specifies the mode for the EXTI lines.
+                                     This parameter can be a value of @ref EXTI_LL_EC_MODE. */
+
+  uint8_t Trigger;              /*!< Specifies the trigger signal active edge for the EXTI lines.
+                                     This parameter can be a value of @ref EXTI_LL_EC_TRIGGER. */
+} LL_EXTI_InitTypeDef;
+
+/**
+  * @}
+  */
+#endif /*USE_FULL_LL_DRIVER*/
+
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup EXTI_LL_Exported_Constants EXTI Exported Constants
+  * @{
+  */
+
+/** @defgroup EXTI_LL_EC_LINE LINE
+  * @{
+  */
+#define LL_EXTI_LINE_0                 EXTI_IMR1_IM0           /*!< Extended line 0 */
+#define LL_EXTI_LINE_1                 EXTI_IMR1_IM1           /*!< Extended line 1 */
+#define LL_EXTI_LINE_2                 EXTI_IMR1_IM2           /*!< Extended line 2 */
+#define LL_EXTI_LINE_3                 EXTI_IMR1_IM3           /*!< Extended line 3 */
+#define LL_EXTI_LINE_4                 EXTI_IMR1_IM4           /*!< Extended line 4 */
+#define LL_EXTI_LINE_5                 EXTI_IMR1_IM5           /*!< Extended line 5 */
+#define LL_EXTI_LINE_6                 EXTI_IMR1_IM6           /*!< Extended line 6 */
+#define LL_EXTI_LINE_7                 EXTI_IMR1_IM7           /*!< Extended line 7 */
+#define LL_EXTI_LINE_8                 EXTI_IMR1_IM8           /*!< Extended line 8 */
+#define LL_EXTI_LINE_9                 EXTI_IMR1_IM9           /*!< Extended line 9 */
+#define LL_EXTI_LINE_10                EXTI_IMR1_IM10          /*!< Extended line 10 */
+#define LL_EXTI_LINE_11                EXTI_IMR1_IM11          /*!< Extended line 11 */
+#define LL_EXTI_LINE_12                EXTI_IMR1_IM12          /*!< Extended line 12 */
+#define LL_EXTI_LINE_13                EXTI_IMR1_IM13          /*!< Extended line 13 */
+#define LL_EXTI_LINE_14                EXTI_IMR1_IM14          /*!< Extended line 14 */
+#define LL_EXTI_LINE_15                EXTI_IMR1_IM15          /*!< Extended line 15 */
+#if defined(EXTI_IMR1_IM16)
+#define LL_EXTI_LINE_16                EXTI_IMR1_IM16          /*!< Extended line 16 */
+#endif
+#define LL_EXTI_LINE_17                EXTI_IMR1_IM17          /*!< Extended line 17 */
+#if defined(EXTI_IMR1_IM18)
+#define LL_EXTI_LINE_18                EXTI_IMR1_IM18          /*!< Extended line 18 */
+#endif
+#define LL_EXTI_LINE_19                EXTI_IMR1_IM19          /*!< Extended line 19 */
+#if defined(EXTI_IMR1_IM20)
+#define LL_EXTI_LINE_20                EXTI_IMR1_IM20          /*!< Extended line 20 */
+#endif
+#if defined(EXTI_IMR1_IM21)
+#define LL_EXTI_LINE_21                EXTI_IMR1_IM21          /*!< Extended line 21 */
+#endif
+#if defined(EXTI_IMR1_IM22)
+#define LL_EXTI_LINE_22                EXTI_IMR1_IM22          /*!< Extended line 22 */
+#endif
+#define LL_EXTI_LINE_23                EXTI_IMR1_IM23          /*!< Extended line 23 */
+#if defined(EXTI_IMR1_IM24)
+#define LL_EXTI_LINE_24                EXTI_IMR1_IM24          /*!< Extended line 24 */
+#endif
+#if defined(EXTI_IMR1_IM25)
+#define LL_EXTI_LINE_25                EXTI_IMR1_IM25          /*!< Extended line 25 */
+#endif
+#if defined(EXTI_IMR1_IM26)
+#define LL_EXTI_LINE_26                EXTI_IMR1_IM26          /*!< Extended line 26 */
+#endif
+#if defined(EXTI_IMR1_IM27)
+#define LL_EXTI_LINE_27                EXTI_IMR1_IM27          /*!< Extended line 27 */
+#endif
+#if defined(EXTI_IMR1_IM28)
+#define LL_EXTI_LINE_28                EXTI_IMR1_IM28          /*!< Extended line 28 */
+#endif
+#if defined(EXTI_IMR1_IM29)
+#define LL_EXTI_LINE_29                EXTI_IMR1_IM29          /*!< Extended line 29 */
+#endif
+#if defined(EXTI_IMR1_IM30)
+#define LL_EXTI_LINE_30                EXTI_IMR1_IM30          /*!< Extended line 30 */
+#endif
+#if defined(EXTI_IMR1_IM31)
+#define LL_EXTI_LINE_31                EXTI_IMR1_IM31          /*!< Extended line 31 */
+#endif
+#define LL_EXTI_LINE_ALL_0_31          EXTI_IMR1_IM            /*!< All Extended line not reserved*/
+
+#define LL_EXTI_LINE_32                EXTI_IMR2_IM32          /*!< Extended line 32 */
+#if defined(EXTI_IMR2_IM33)
+#define LL_EXTI_LINE_33                EXTI_IMR2_IM33          /*!< Extended line 33 */
+#endif
+#if defined(EXTI_IMR2_IM34)
+#define LL_EXTI_LINE_34                EXTI_IMR2_IM34          /*!< Extended line 34 */
+#endif
+#if defined(EXTI_IMR2_IM35)
+#define LL_EXTI_LINE_35                EXTI_IMR2_IM35          /*!< Extended line 35 */
+#endif
+#if defined(EXTI_IMR2_IM36)
+#define LL_EXTI_LINE_36                EXTI_IMR2_IM36          /*!< Extended line 36 */
+#endif
+#if defined(EXTI_IMR2_IM37)
+#define LL_EXTI_LINE_37                EXTI_IMR2_IM37          /*!< Extended line 37 */
+#endif
+#if defined(EXTI_IMR2_IM38)
+#define LL_EXTI_LINE_38                EXTI_IMR2_IM38          /*!< Extended line 38 */
+#endif
+#if defined(EXTI_IMR2_IM39)
+#define LL_EXTI_LINE_39                EXTI_IMR2_IM39          /*!< Extended line 39 */
+#endif
+#if defined(EXTI_IMR2_IM40)
+#define LL_EXTI_LINE_40                EXTI_IMR2_IM40          /*!< Extended line 40 */
+#endif
+#define LL_EXTI_LINE_ALL_32_63         EXTI_IMR2_IM            /*!< All Extended line not reserved*/
+
+
+#define LL_EXTI_LINE_ALL               (0xFFFFFFFFU)  /*!< All Extended line */
+
+#if defined(USE_FULL_LL_DRIVER)
+#define LL_EXTI_LINE_NONE              (0x00000000U)  /*!< None Extended line */
+#endif /*USE_FULL_LL_DRIVER*/
+
+/**
+  * @}
+  */
+
+
+#if defined(USE_FULL_LL_DRIVER)
+
+/** @defgroup EXTI_LL_EC_MODE Mode
+  * @{
+  */
+#define LL_EXTI_MODE_IT                 ((uint8_t)0x00U) /*!< Interrupt Mode */
+#define LL_EXTI_MODE_EVENT              ((uint8_t)0x01U) /*!< Event Mode */
+#define LL_EXTI_MODE_IT_EVENT           ((uint8_t)0x02U) /*!< Interrupt & Event Mode */
+/**
+  * @}
+  */
+
+/** @defgroup EXTI_LL_EC_TRIGGER Edge Trigger
+  * @{
+  */
+#define LL_EXTI_TRIGGER_NONE            ((uint8_t)0x00U) /*!< No Trigger Mode */
+#define LL_EXTI_TRIGGER_RISING          ((uint8_t)0x01U) /*!< Trigger Rising Mode */
+#define LL_EXTI_TRIGGER_FALLING         ((uint8_t)0x02U) /*!< Trigger Falling Mode */
+#define LL_EXTI_TRIGGER_RISING_FALLING  ((uint8_t)0x03U) /*!< Trigger Rising & Falling Mode */
+
+/**
+  * @}
+  */
+
+
+#endif /*USE_FULL_LL_DRIVER*/
+
+
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+/** @defgroup EXTI_LL_Exported_Macros EXTI Exported Macros
+  * @{
+  */
+
+/** @defgroup EXTI_LL_EM_WRITE_READ Common Write and read registers Macros
+  * @{
+  */
+
+/**
+  * @brief  Write a value in EXTI register
+  * @param  __REG__ Register to be written
+  * @param  __VALUE__ Value to be written in the register
+  * @retval None
+  */
+#define LL_EXTI_WriteReg(__REG__, __VALUE__) WRITE_REG(EXTI->__REG__, (__VALUE__))
+
+/**
+  * @brief  Read a value in EXTI register
+  * @param  __REG__ Register to be read
+  * @retval Register value
+  */
+#define LL_EXTI_ReadReg(__REG__) READ_REG(EXTI->__REG__)
+/**
+  * @}
+  */
+
+
+/**
+  * @}
+  */
+
+
+
+/* Exported functions --------------------------------------------------------*/
+/** @defgroup EXTI_LL_Exported_Functions EXTI Exported Functions
+ * @{
+ */
+/** @defgroup EXTI_LL_EF_IT_Management IT_Management
+  * @{
+  */
+
+/**
+  * @brief  Enable ExtiLine Interrupt request for Lines in range 0 to 31
+  * @note The reset value for the direct or internal lines (see RM)
+  *       is set to 1 in order to enable the interrupt by default.
+  *       Bits are set automatically at Power on.
+  * @rmtoll IMR1         IMx           LL_EXTI_EnableIT_0_31
+  * @param  ExtiLine This parameter can be one of the following values:
+  *         @arg @ref LL_EXTI_LINE_0
+  *         @arg @ref LL_EXTI_LINE_1
+  *         @arg @ref LL_EXTI_LINE_2
+  *         @arg @ref LL_EXTI_LINE_3
+  *         @arg @ref LL_EXTI_LINE_4
+  *         @arg @ref LL_EXTI_LINE_5
+  *         @arg @ref LL_EXTI_LINE_6
+  *         @arg @ref LL_EXTI_LINE_7
+  *         @arg @ref LL_EXTI_LINE_8
+  *         @arg @ref LL_EXTI_LINE_9
+  *         @arg @ref LL_EXTI_LINE_10
+  *         @arg @ref LL_EXTI_LINE_11
+  *         @arg @ref LL_EXTI_LINE_12
+  *         @arg @ref LL_EXTI_LINE_13
+  *         @arg @ref LL_EXTI_LINE_14
+  *         @arg @ref LL_EXTI_LINE_15
+  *         @arg @ref LL_EXTI_LINE_16
+  *         @arg @ref LL_EXTI_LINE_17
+  *         @arg @ref LL_EXTI_LINE_18
+  *         @arg @ref LL_EXTI_LINE_19
+  *         @arg @ref LL_EXTI_LINE_20
+  *         @arg @ref LL_EXTI_LINE_21
+  *         @arg @ref LL_EXTI_LINE_22
+  *         @arg @ref LL_EXTI_LINE_23
+  *         @arg @ref LL_EXTI_LINE_24
+  *         @arg @ref LL_EXTI_LINE_25
+  *         @arg @ref LL_EXTI_LINE_26
+  *         @arg @ref LL_EXTI_LINE_27
+  *         @arg @ref LL_EXTI_LINE_28
+  *         @arg @ref LL_EXTI_LINE_29
+  *         @arg @ref LL_EXTI_LINE_30
+  *         @arg @ref LL_EXTI_LINE_31
+  *         @arg @ref LL_EXTI_LINE_ALL_0_31
+  * @note   Please check each device line mapping for EXTI Line availability
+  * @retval None
+  */
+__STATIC_INLINE void LL_EXTI_EnableIT_0_31(uint32_t ExtiLine)
+{
+  SET_BIT(EXTI->IMR1, ExtiLine);
+}
+/**
+  * @brief  Enable ExtiLine Interrupt request for Lines in range 32 to 63
+  * @note The reset value for the direct lines (lines from 32 to 34, line
+  *       39) is set to 1 in order to enable the interrupt by default.
+  *       Bits are set automatically at Power on.
+  * @rmtoll IMR2         IMx           LL_EXTI_EnableIT_32_63
+  * @param  ExtiLine This parameter can be one of the following values:
+  *         @arg @ref LL_EXTI_LINE_32
+  *         @arg @ref LL_EXTI_LINE_33
+  *         @arg @ref LL_EXTI_LINE_34(*)
+  *         @arg @ref LL_EXTI_LINE_35
+  *         @arg @ref LL_EXTI_LINE_36
+  *         @arg @ref LL_EXTI_LINE_37
+  *         @arg @ref LL_EXTI_LINE_38
+  *         @arg @ref LL_EXTI_LINE_39(*)
+  *         @arg @ref LL_EXTI_LINE_40(*)
+  *         @arg @ref LL_EXTI_LINE_ALL_32_63
+  * @note   (*): Available in some devices
+  * @retval None
+  */
+__STATIC_INLINE void LL_EXTI_EnableIT_32_63(uint32_t ExtiLine)
+{
+  SET_BIT(EXTI->IMR2, ExtiLine);
+}
+
+/**
+  * @brief  Disable ExtiLine Interrupt request for Lines in range 0 to 31
+  * @note The reset value for the direct or internal lines (see RM)
+  *       is set to 1 in order to enable the interrupt by default.
+  *       Bits are set automatically at Power on.
+  * @rmtoll IMR1         IMx           LL_EXTI_DisableIT_0_31
+  * @param  ExtiLine This parameter can be one of the following values:
+  *         @arg @ref LL_EXTI_LINE_0
+  *         @arg @ref LL_EXTI_LINE_1
+  *         @arg @ref LL_EXTI_LINE_2
+  *         @arg @ref LL_EXTI_LINE_3
+  *         @arg @ref LL_EXTI_LINE_4
+  *         @arg @ref LL_EXTI_LINE_5
+  *         @arg @ref LL_EXTI_LINE_6
+  *         @arg @ref LL_EXTI_LINE_7
+  *         @arg @ref LL_EXTI_LINE_8
+  *         @arg @ref LL_EXTI_LINE_9
+  *         @arg @ref LL_EXTI_LINE_10
+  *         @arg @ref LL_EXTI_LINE_11
+  *         @arg @ref LL_EXTI_LINE_12
+  *         @arg @ref LL_EXTI_LINE_13
+  *         @arg @ref LL_EXTI_LINE_14
+  *         @arg @ref LL_EXTI_LINE_15
+  *         @arg @ref LL_EXTI_LINE_16
+  *         @arg @ref LL_EXTI_LINE_17
+  *         @arg @ref LL_EXTI_LINE_18
+  *         @arg @ref LL_EXTI_LINE_19
+  *         @arg @ref LL_EXTI_LINE_20
+  *         @arg @ref LL_EXTI_LINE_21
+  *         @arg @ref LL_EXTI_LINE_22
+  *         @arg @ref LL_EXTI_LINE_23
+  *         @arg @ref LL_EXTI_LINE_24
+  *         @arg @ref LL_EXTI_LINE_25
+  *         @arg @ref LL_EXTI_LINE_26
+  *         @arg @ref LL_EXTI_LINE_27
+  *         @arg @ref LL_EXTI_LINE_28
+  *         @arg @ref LL_EXTI_LINE_29
+  *         @arg @ref LL_EXTI_LINE_30
+  *         @arg @ref LL_EXTI_LINE_31
+  *         @arg @ref LL_EXTI_LINE_ALL_0_31
+  * @note   Please check each device line mapping for EXTI Line availability
+  * @retval None
+  */
+__STATIC_INLINE void LL_EXTI_DisableIT_0_31(uint32_t ExtiLine)
+{
+  CLEAR_BIT(EXTI->IMR1, ExtiLine);
+}
+
+/**
+  * @brief  Disable ExtiLine Interrupt request for Lines in range 32 to 63
+  * @note The reset value for the direct lines (lines from 32 to 34, line
+  *       39) is set to 1 in order to enable the interrupt by default.
+  *       Bits are set automatically at Power on.
+  * @rmtoll IMR2         IMx           LL_EXTI_DisableIT_32_63
+  * @param  ExtiLine This parameter can be one of the following values:
+  *         @arg @ref LL_EXTI_LINE_32
+  *         @arg @ref LL_EXTI_LINE_33
+  *         @arg @ref LL_EXTI_LINE_34(*)
+  *         @arg @ref LL_EXTI_LINE_35
+  *         @arg @ref LL_EXTI_LINE_36
+  *         @arg @ref LL_EXTI_LINE_37
+  *         @arg @ref LL_EXTI_LINE_38
+  *         @arg @ref LL_EXTI_LINE_39(*)
+  *         @arg @ref LL_EXTI_LINE_40(*)
+  *         @arg @ref LL_EXTI_LINE_ALL_32_63
+  * @note   (*): Available in some devices
+  * @retval None
+  */
+__STATIC_INLINE void LL_EXTI_DisableIT_32_63(uint32_t ExtiLine)
+{
+  CLEAR_BIT(EXTI->IMR2, ExtiLine);
+}
+
+/**
+  * @brief  Indicate if ExtiLine Interrupt request is enabled for Lines in range 0 to 31
+  * @note The reset value for the direct or internal lines (see RM)
+  *       is set to 1 in order to enable the interrupt by default.
+  *       Bits are set automatically at Power on.
+  * @rmtoll IMR1         IMx           LL_EXTI_IsEnabledIT_0_31
+  * @param  ExtiLine This parameter can be one of the following values:
+  *         @arg @ref LL_EXTI_LINE_0
+  *         @arg @ref LL_EXTI_LINE_1
+  *         @arg @ref LL_EXTI_LINE_2
+  *         @arg @ref LL_EXTI_LINE_3
+  *         @arg @ref LL_EXTI_LINE_4
+  *         @arg @ref LL_EXTI_LINE_5
+  *         @arg @ref LL_EXTI_LINE_6
+  *         @arg @ref LL_EXTI_LINE_7
+  *         @arg @ref LL_EXTI_LINE_8
+  *         @arg @ref LL_EXTI_LINE_9
+  *         @arg @ref LL_EXTI_LINE_10
+  *         @arg @ref LL_EXTI_LINE_11
+  *         @arg @ref LL_EXTI_LINE_12
+  *         @arg @ref LL_EXTI_LINE_13
+  *         @arg @ref LL_EXTI_LINE_14
+  *         @arg @ref LL_EXTI_LINE_15
+  *         @arg @ref LL_EXTI_LINE_16
+  *         @arg @ref LL_EXTI_LINE_17
+  *         @arg @ref LL_EXTI_LINE_18
+  *         @arg @ref LL_EXTI_LINE_19
+  *         @arg @ref LL_EXTI_LINE_20
+  *         @arg @ref LL_EXTI_LINE_21
+  *         @arg @ref LL_EXTI_LINE_22
+  *         @arg @ref LL_EXTI_LINE_23
+  *         @arg @ref LL_EXTI_LINE_24
+  *         @arg @ref LL_EXTI_LINE_25
+  *         @arg @ref LL_EXTI_LINE_26
+  *         @arg @ref LL_EXTI_LINE_27
+  *         @arg @ref LL_EXTI_LINE_28
+  *         @arg @ref LL_EXTI_LINE_29
+  *         @arg @ref LL_EXTI_LINE_30
+  *         @arg @ref LL_EXTI_LINE_31
+  *         @arg @ref LL_EXTI_LINE_ALL_0_31
+  * @note   Please check each device line mapping for EXTI Line availability
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_EXTI_IsEnabledIT_0_31(uint32_t ExtiLine)
+{
+  return ((READ_BIT(EXTI->IMR1, ExtiLine) == (ExtiLine)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Indicate if ExtiLine Interrupt request is enabled for Lines in range 32 to 63
+  * @note The reset value for the direct lines (lines from 32 to 34, line
+  *       39) is set to 1 in order to enable the interrupt by default.
+  *       Bits are set automatically at Power on.
+  * @rmtoll IMR2         IMx           LL_EXTI_IsEnabledIT_32_63
+  * @param  ExtiLine This parameter can be one of the following values:
+  *         @arg @ref LL_EXTI_LINE_32
+  *         @arg @ref LL_EXTI_LINE_33
+  *         @arg @ref LL_EXTI_LINE_34(*)
+  *         @arg @ref LL_EXTI_LINE_35
+  *         @arg @ref LL_EXTI_LINE_36
+  *         @arg @ref LL_EXTI_LINE_37
+  *         @arg @ref LL_EXTI_LINE_38
+  *         @arg @ref LL_EXTI_LINE_39(*)
+  *         @arg @ref LL_EXTI_LINE_40(*)
+  *         @arg @ref LL_EXTI_LINE_ALL_32_63
+  * @note   (*): Available in some devices
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_EXTI_IsEnabledIT_32_63(uint32_t ExtiLine)
+{
+  return ((READ_BIT(EXTI->IMR2, ExtiLine) == (ExtiLine)) ? 1UL : 0UL);
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup EXTI_LL_EF_Event_Management Event_Management
+  * @{
+  */
+
+/**
+  * @brief  Enable ExtiLine Event request for Lines in range 0 to 31
+  * @rmtoll EMR1         EMx           LL_EXTI_EnableEvent_0_31
+  * @param  ExtiLine This parameter can be one of the following values:
+  *         @arg @ref LL_EXTI_LINE_0
+  *         @arg @ref LL_EXTI_LINE_1
+  *         @arg @ref LL_EXTI_LINE_2
+  *         @arg @ref LL_EXTI_LINE_3
+  *         @arg @ref LL_EXTI_LINE_4
+  *         @arg @ref LL_EXTI_LINE_5
+  *         @arg @ref LL_EXTI_LINE_6
+  *         @arg @ref LL_EXTI_LINE_7
+  *         @arg @ref LL_EXTI_LINE_8
+  *         @arg @ref LL_EXTI_LINE_9
+  *         @arg @ref LL_EXTI_LINE_10
+  *         @arg @ref LL_EXTI_LINE_11
+  *         @arg @ref LL_EXTI_LINE_12
+  *         @arg @ref LL_EXTI_LINE_13
+  *         @arg @ref LL_EXTI_LINE_14
+  *         @arg @ref LL_EXTI_LINE_15
+  *         @arg @ref LL_EXTI_LINE_16
+  *         @arg @ref LL_EXTI_LINE_17
+  *         @arg @ref LL_EXTI_LINE_18
+  *         @arg @ref LL_EXTI_LINE_19
+  *         @arg @ref LL_EXTI_LINE_20
+  *         @arg @ref LL_EXTI_LINE_21
+  *         @arg @ref LL_EXTI_LINE_22
+  *         @arg @ref LL_EXTI_LINE_23
+  *         @arg @ref LL_EXTI_LINE_24
+  *         @arg @ref LL_EXTI_LINE_25
+  *         @arg @ref LL_EXTI_LINE_26
+  *         @arg @ref LL_EXTI_LINE_27
+  *         @arg @ref LL_EXTI_LINE_28
+  *         @arg @ref LL_EXTI_LINE_29
+  *         @arg @ref LL_EXTI_LINE_30
+  *         @arg @ref LL_EXTI_LINE_31
+  *         @arg @ref LL_EXTI_LINE_ALL_0_31
+  * @note   Please check each device line mapping for EXTI Line availability
+  * @retval None
+  */
+__STATIC_INLINE void LL_EXTI_EnableEvent_0_31(uint32_t ExtiLine)
+{
+  SET_BIT(EXTI->EMR1, ExtiLine);
+
+}
+
+/**
+  * @brief  Enable ExtiLine Event request for Lines in range 32 to 63
+  * @rmtoll EMR2         EMx           LL_EXTI_EnableEvent_32_63
+  * @param  ExtiLine This parameter can be a combination of the following values:
+  *         @arg @ref LL_EXTI_LINE_32
+  *         @arg @ref LL_EXTI_LINE_33
+  *         @arg @ref LL_EXTI_LINE_34(*)
+  *         @arg @ref LL_EXTI_LINE_35
+  *         @arg @ref LL_EXTI_LINE_36
+  *         @arg @ref LL_EXTI_LINE_37
+  *         @arg @ref LL_EXTI_LINE_38
+  *         @arg @ref LL_EXTI_LINE_39(*)
+  *         @arg @ref LL_EXTI_LINE_40(*)
+  *         @arg @ref LL_EXTI_LINE_ALL_32_63
+  * @note   (*): Available in some devices
+  * @retval None
+  */
+__STATIC_INLINE void LL_EXTI_EnableEvent_32_63(uint32_t ExtiLine)
+{
+  SET_BIT(EXTI->EMR2, ExtiLine);
+}
+
+/**
+  * @brief  Disable ExtiLine Event request for Lines in range 0 to 31
+  * @rmtoll EMR1         EMx           LL_EXTI_DisableEvent_0_31
+  * @param  ExtiLine This parameter can be one of the following values:
+  *         @arg @ref LL_EXTI_LINE_0
+  *         @arg @ref LL_EXTI_LINE_1
+  *         @arg @ref LL_EXTI_LINE_2
+  *         @arg @ref LL_EXTI_LINE_3
+  *         @arg @ref LL_EXTI_LINE_4
+  *         @arg @ref LL_EXTI_LINE_5
+  *         @arg @ref LL_EXTI_LINE_6
+  *         @arg @ref LL_EXTI_LINE_7
+  *         @arg @ref LL_EXTI_LINE_8
+  *         @arg @ref LL_EXTI_LINE_9
+  *         @arg @ref LL_EXTI_LINE_10
+  *         @arg @ref LL_EXTI_LINE_11
+  *         @arg @ref LL_EXTI_LINE_12
+  *         @arg @ref LL_EXTI_LINE_13
+  *         @arg @ref LL_EXTI_LINE_14
+  *         @arg @ref LL_EXTI_LINE_15
+  *         @arg @ref LL_EXTI_LINE_16
+  *         @arg @ref LL_EXTI_LINE_17
+  *         @arg @ref LL_EXTI_LINE_18
+  *         @arg @ref LL_EXTI_LINE_19
+  *         @arg @ref LL_EXTI_LINE_20
+  *         @arg @ref LL_EXTI_LINE_21
+  *         @arg @ref LL_EXTI_LINE_22
+  *         @arg @ref LL_EXTI_LINE_23
+  *         @arg @ref LL_EXTI_LINE_24
+  *         @arg @ref LL_EXTI_LINE_25
+  *         @arg @ref LL_EXTI_LINE_26
+  *         @arg @ref LL_EXTI_LINE_27
+  *         @arg @ref LL_EXTI_LINE_28
+  *         @arg @ref LL_EXTI_LINE_29
+  *         @arg @ref LL_EXTI_LINE_30
+  *         @arg @ref LL_EXTI_LINE_31
+  *         @arg @ref LL_EXTI_LINE_ALL_0_31
+  * @note   Please check each device line mapping for EXTI Line availability
+  * @retval None
+  */
+__STATIC_INLINE void LL_EXTI_DisableEvent_0_31(uint32_t ExtiLine)
+{
+  CLEAR_BIT(EXTI->EMR1, ExtiLine);
+}
+
+/**
+  * @brief  Disable ExtiLine Event request for Lines in range 32 to 63
+  * @rmtoll EMR2         EMx           LL_EXTI_DisableEvent_32_63
+  * @param  ExtiLine This parameter can be a combination of the following values:
+  *         @arg @ref LL_EXTI_LINE_32
+  *         @arg @ref LL_EXTI_LINE_33
+  *         @arg @ref LL_EXTI_LINE_34(*)
+  *         @arg @ref LL_EXTI_LINE_35
+  *         @arg @ref LL_EXTI_LINE_36
+  *         @arg @ref LL_EXTI_LINE_37
+  *         @arg @ref LL_EXTI_LINE_38
+  *         @arg @ref LL_EXTI_LINE_39(*)
+  *         @arg @ref LL_EXTI_LINE_40(*)
+  *         @arg @ref LL_EXTI_LINE_ALL_32_63
+  * @note   (*): Available in some devices
+  * @retval None
+  */
+__STATIC_INLINE void LL_EXTI_DisableEvent_32_63(uint32_t ExtiLine)
+{
+  CLEAR_BIT(EXTI->EMR2, ExtiLine);
+}
+
+/**
+  * @brief  Indicate if ExtiLine Event request is enabled for Lines in range 0 to 31
+  * @rmtoll EMR1         EMx           LL_EXTI_IsEnabledEvent_0_31
+  * @param  ExtiLine This parameter can be one of the following values:
+  *         @arg @ref LL_EXTI_LINE_0
+  *         @arg @ref LL_EXTI_LINE_1
+  *         @arg @ref LL_EXTI_LINE_2
+  *         @arg @ref LL_EXTI_LINE_3
+  *         @arg @ref LL_EXTI_LINE_4
+  *         @arg @ref LL_EXTI_LINE_5
+  *         @arg @ref LL_EXTI_LINE_6
+  *         @arg @ref LL_EXTI_LINE_7
+  *         @arg @ref LL_EXTI_LINE_8
+  *         @arg @ref LL_EXTI_LINE_9
+  *         @arg @ref LL_EXTI_LINE_10
+  *         @arg @ref LL_EXTI_LINE_11
+  *         @arg @ref LL_EXTI_LINE_12
+  *         @arg @ref LL_EXTI_LINE_13
+  *         @arg @ref LL_EXTI_LINE_14
+  *         @arg @ref LL_EXTI_LINE_15
+  *         @arg @ref LL_EXTI_LINE_16
+  *         @arg @ref LL_EXTI_LINE_17
+  *         @arg @ref LL_EXTI_LINE_18
+  *         @arg @ref LL_EXTI_LINE_19
+  *         @arg @ref LL_EXTI_LINE_20
+  *         @arg @ref LL_EXTI_LINE_21
+  *         @arg @ref LL_EXTI_LINE_22
+  *         @arg @ref LL_EXTI_LINE_23
+  *         @arg @ref LL_EXTI_LINE_24
+  *         @arg @ref LL_EXTI_LINE_25
+  *         @arg @ref LL_EXTI_LINE_26
+  *         @arg @ref LL_EXTI_LINE_27
+  *         @arg @ref LL_EXTI_LINE_28
+  *         @arg @ref LL_EXTI_LINE_29
+  *         @arg @ref LL_EXTI_LINE_30
+  *         @arg @ref LL_EXTI_LINE_31
+  *         @arg @ref LL_EXTI_LINE_ALL_0_31
+  * @note   Please check each device line mapping for EXTI Line availability
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_EXTI_IsEnabledEvent_0_31(uint32_t ExtiLine)
+{
+  return ((READ_BIT(EXTI->EMR1, ExtiLine) == (ExtiLine)) ? 1UL : 0UL);
+
+}
+
+/**
+  * @brief  Indicate if ExtiLine Event request is enabled for Lines in range 32 to 63
+  * @rmtoll EMR2         EMx           LL_EXTI_IsEnabledEvent_32_63
+  * @param  ExtiLine This parameter can be a combination of the following values:
+  *         @arg @ref LL_EXTI_LINE_32
+  *         @arg @ref LL_EXTI_LINE_33
+  *         @arg @ref LL_EXTI_LINE_34(*)
+  *         @arg @ref LL_EXTI_LINE_35
+  *         @arg @ref LL_EXTI_LINE_36
+  *         @arg @ref LL_EXTI_LINE_37
+  *         @arg @ref LL_EXTI_LINE_38
+  *         @arg @ref LL_EXTI_LINE_39(*)
+  *         @arg @ref LL_EXTI_LINE_40(*)
+  *         @arg @ref LL_EXTI_LINE_ALL_32_63
+  * @note   (*): Available in some devices
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_EXTI_IsEnabledEvent_32_63(uint32_t ExtiLine)
+{
+  return ((READ_BIT(EXTI->EMR2, ExtiLine) == (ExtiLine)) ? 1UL : 0UL);
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup EXTI_LL_EF_Rising_Trigger_Management Rising_Trigger_Management
+  * @{
+  */
+
+/**
+  * @brief  Enable ExtiLine Rising Edge Trigger for Lines in range 0 to 31
+  * @note The configurable wakeup lines are edge-triggered. No glitch must be
+  *       generated on these lines. If a rising edge on a configurable interrupt
+  *       line occurs during a write operation in the EXTI_RTSR register, the
+  *       pending bit is not set.
+  *       Rising and falling edge triggers can be set for
+  *       the same interrupt line. In this case, both generate a trigger
+  *       condition.
+  * @rmtoll RTSR1        RTx           LL_EXTI_EnableRisingTrig_0_31
+  * @param  ExtiLine This parameter can be a combination of the following values:
+  *         @arg @ref LL_EXTI_LINE_0
+  *         @arg @ref LL_EXTI_LINE_1
+  *         @arg @ref LL_EXTI_LINE_2
+  *         @arg @ref LL_EXTI_LINE_3
+  *         @arg @ref LL_EXTI_LINE_4
+  *         @arg @ref LL_EXTI_LINE_5
+  *         @arg @ref LL_EXTI_LINE_6
+  *         @arg @ref LL_EXTI_LINE_7
+  *         @arg @ref LL_EXTI_LINE_8
+  *         @arg @ref LL_EXTI_LINE_9
+  *         @arg @ref LL_EXTI_LINE_10
+  *         @arg @ref LL_EXTI_LINE_11
+  *         @arg @ref LL_EXTI_LINE_12
+  *         @arg @ref LL_EXTI_LINE_13
+  *         @arg @ref LL_EXTI_LINE_14
+  *         @arg @ref LL_EXTI_LINE_15
+  *         @arg @ref LL_EXTI_LINE_16
+  *         @arg @ref LL_EXTI_LINE_18
+  *         @arg @ref LL_EXTI_LINE_19
+  *         @arg @ref LL_EXTI_LINE_20
+  *         @arg @ref LL_EXTI_LINE_21
+  *         @arg @ref LL_EXTI_LINE_22
+  *         @arg @ref LL_EXTI_LINE_29
+  *         @arg @ref LL_EXTI_LINE_30
+  *         @arg @ref LL_EXTI_LINE_31
+  * @note   Please check each device line mapping for EXTI Line availability
+  * @retval None
+  */
+__STATIC_INLINE void LL_EXTI_EnableRisingTrig_0_31(uint32_t ExtiLine)
+{
+  SET_BIT(EXTI->RTSR1, ExtiLine);
+
+}
+
+/**
+  * @brief  Enable ExtiLine Rising Edge Trigger for Lines in range 32 to 63
+  * @note The configurable wakeup lines are edge-triggered. No glitch must be
+  *       generated on these lines. If a rising edge on a configurable interrupt
+  *       line occurs during a write operation in the EXTI_RTSR register, the
+  *       pending bit is not set.Rising and falling edge triggers can be set for
+  *       the same interrupt line. In this case, both generate a trigger
+  *       condition.
+  * @rmtoll RTSR2        RTx           LL_EXTI_EnableRisingTrig_32_63
+  * @param  ExtiLine This parameter can be a combination of the following values:
+  *         @arg @ref LL_EXTI_LINE_35
+  *         @arg @ref LL_EXTI_LINE_36
+  *         @arg @ref LL_EXTI_LINE_37
+  *         @arg @ref LL_EXTI_LINE_38
+  * @retval None
+  */
+__STATIC_INLINE void LL_EXTI_EnableRisingTrig_32_63(uint32_t ExtiLine)
+{
+  SET_BIT(EXTI->RTSR2, ExtiLine);
+}
+
+/**
+  * @brief  Disable ExtiLine Rising Edge Trigger for Lines in range 0 to 31
+  * @note The configurable wakeup lines are edge-triggered. No glitch must be
+  *       generated on these lines. If a rising edge on a configurable interrupt
+  *       line occurs during a write operation in the EXTI_RTSR register, the
+  *       pending bit is not set.
+  *       Rising and falling edge triggers can be set for
+  *       the same interrupt line. In this case, both generate a trigger
+  *       condition.
+  * @rmtoll RTSR1        RTx           LL_EXTI_DisableRisingTrig_0_31
+  * @param  ExtiLine This parameter can be a combination of the following values:
+  *         @arg @ref LL_EXTI_LINE_0
+  *         @arg @ref LL_EXTI_LINE_1
+  *         @arg @ref LL_EXTI_LINE_2
+  *         @arg @ref LL_EXTI_LINE_3
+  *         @arg @ref LL_EXTI_LINE_4
+  *         @arg @ref LL_EXTI_LINE_5
+  *         @arg @ref LL_EXTI_LINE_6
+  *         @arg @ref LL_EXTI_LINE_7
+  *         @arg @ref LL_EXTI_LINE_8
+  *         @arg @ref LL_EXTI_LINE_9
+  *         @arg @ref LL_EXTI_LINE_10
+  *         @arg @ref LL_EXTI_LINE_11
+  *         @arg @ref LL_EXTI_LINE_12
+  *         @arg @ref LL_EXTI_LINE_13
+  *         @arg @ref LL_EXTI_LINE_14
+  *         @arg @ref LL_EXTI_LINE_15
+  *         @arg @ref LL_EXTI_LINE_16
+  *         @arg @ref LL_EXTI_LINE_18
+  *         @arg @ref LL_EXTI_LINE_19
+  *         @arg @ref LL_EXTI_LINE_20
+  *         @arg @ref LL_EXTI_LINE_21
+  *         @arg @ref LL_EXTI_LINE_22
+  *         @arg @ref LL_EXTI_LINE_29
+  *         @arg @ref LL_EXTI_LINE_30
+  *         @arg @ref LL_EXTI_LINE_31
+  * @note   Please check each device line mapping for EXTI Line availability
+  * @retval None
+  */
+__STATIC_INLINE void LL_EXTI_DisableRisingTrig_0_31(uint32_t ExtiLine)
+{
+  CLEAR_BIT(EXTI->RTSR1, ExtiLine);
+
+}
+
+/**
+  * @brief  Disable ExtiLine Rising Edge Trigger for Lines in range 32 to 63
+  * @note The configurable wakeup lines are edge-triggered. No glitch must be
+  *       generated on these lines. If a rising edge on a configurable interrupt
+  *       line occurs during a write operation in the EXTI_RTSR register, the
+  *       pending bit is not set.
+  *       Rising and falling edge triggers can be set for
+  *       the same interrupt line. In this case, both generate a trigger
+  *       condition.
+  * @rmtoll RTSR2        RTx           LL_EXTI_DisableRisingTrig_32_63
+  * @param  ExtiLine This parameter can be a combination of the following values:
+  *         @arg @ref LL_EXTI_LINE_35
+  *         @arg @ref LL_EXTI_LINE_36
+  *         @arg @ref LL_EXTI_LINE_37
+  *         @arg @ref LL_EXTI_LINE_38
+  * @retval None
+  */
+__STATIC_INLINE void LL_EXTI_DisableRisingTrig_32_63(uint32_t ExtiLine)
+{
+  CLEAR_BIT(EXTI->RTSR2, ExtiLine);
+}
+
+/**
+  * @brief  Check if rising edge trigger is enabled for Lines in range 0 to 31
+  * @rmtoll RTSR1        RTx           LL_EXTI_IsEnabledRisingTrig_0_31
+  * @param  ExtiLine This parameter can be a combination of the following values:
+  *         @arg @ref LL_EXTI_LINE_0
+  *         @arg @ref LL_EXTI_LINE_1
+  *         @arg @ref LL_EXTI_LINE_2
+  *         @arg @ref LL_EXTI_LINE_3
+  *         @arg @ref LL_EXTI_LINE_4
+  *         @arg @ref LL_EXTI_LINE_5
+  *         @arg @ref LL_EXTI_LINE_6
+  *         @arg @ref LL_EXTI_LINE_7
+  *         @arg @ref LL_EXTI_LINE_8
+  *         @arg @ref LL_EXTI_LINE_9
+  *         @arg @ref LL_EXTI_LINE_10
+  *         @arg @ref LL_EXTI_LINE_11
+  *         @arg @ref LL_EXTI_LINE_12
+  *         @arg @ref LL_EXTI_LINE_13
+  *         @arg @ref LL_EXTI_LINE_14
+  *         @arg @ref LL_EXTI_LINE_15
+  *         @arg @ref LL_EXTI_LINE_16
+  *         @arg @ref LL_EXTI_LINE_18
+  *         @arg @ref LL_EXTI_LINE_19
+  *         @arg @ref LL_EXTI_LINE_20
+  *         @arg @ref LL_EXTI_LINE_21
+  *         @arg @ref LL_EXTI_LINE_22
+  *         @arg @ref LL_EXTI_LINE_29
+  *         @arg @ref LL_EXTI_LINE_30
+  *         @arg @ref LL_EXTI_LINE_31
+  * @note   Please check each device line mapping for EXTI Line availability
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_EXTI_IsEnabledRisingTrig_0_31(uint32_t ExtiLine)
+{
+  return ((READ_BIT(EXTI->RTSR1, ExtiLine) == (ExtiLine)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Check if rising edge trigger is enabled for Lines in range 32 to 63
+  * @rmtoll RTSR2        RTx           LL_EXTI_IsEnabledRisingTrig_32_63
+  * @param  ExtiLine This parameter can be a combination of the following values:
+  *         @arg @ref LL_EXTI_LINE_35
+  *         @arg @ref LL_EXTI_LINE_36
+  *         @arg @ref LL_EXTI_LINE_37
+  *         @arg @ref LL_EXTI_LINE_38
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_EXTI_IsEnabledRisingTrig_32_63(uint32_t ExtiLine)
+{
+  return ((READ_BIT(EXTI->RTSR2, ExtiLine) == (ExtiLine)) ? 1UL : 0UL);
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup EXTI_LL_EF_Falling_Trigger_Management Falling_Trigger_Management
+  * @{
+  */
+
+/**
+  * @brief  Enable ExtiLine Falling Edge Trigger for Lines in range 0 to 31
+  * @note The configurable wakeup lines are edge-triggered. No glitch must be
+  *       generated on these lines. If a falling edge on a configurable interrupt
+  *       line occurs during a write operation in the EXTI_FTSR register, the
+  *       pending bit is not set.
+  *       Rising and falling edge triggers can be set for
+  *       the same interrupt line. In this case, both generate a trigger
+  *       condition.
+  * @rmtoll FTSR1        FTx           LL_EXTI_EnableFallingTrig_0_31
+  * @param  ExtiLine This parameter can be a combination of the following values:
+  *         @arg @ref LL_EXTI_LINE_0
+  *         @arg @ref LL_EXTI_LINE_1
+  *         @arg @ref LL_EXTI_LINE_2
+  *         @arg @ref LL_EXTI_LINE_3
+  *         @arg @ref LL_EXTI_LINE_4
+  *         @arg @ref LL_EXTI_LINE_5
+  *         @arg @ref LL_EXTI_LINE_6
+  *         @arg @ref LL_EXTI_LINE_7
+  *         @arg @ref LL_EXTI_LINE_8
+  *         @arg @ref LL_EXTI_LINE_9
+  *         @arg @ref LL_EXTI_LINE_10
+  *         @arg @ref LL_EXTI_LINE_11
+  *         @arg @ref LL_EXTI_LINE_12
+  *         @arg @ref LL_EXTI_LINE_13
+  *         @arg @ref LL_EXTI_LINE_14
+  *         @arg @ref LL_EXTI_LINE_15
+  *         @arg @ref LL_EXTI_LINE_16
+  *         @arg @ref LL_EXTI_LINE_18
+  *         @arg @ref LL_EXTI_LINE_19
+  *         @arg @ref LL_EXTI_LINE_20
+  *         @arg @ref LL_EXTI_LINE_21
+  *         @arg @ref LL_EXTI_LINE_22
+  *         @arg @ref LL_EXTI_LINE_29
+  *         @arg @ref LL_EXTI_LINE_30
+  *         @arg @ref LL_EXTI_LINE_31
+  * @note   Please check each device line mapping for EXTI Line availability
+  * @retval None
+  */
+__STATIC_INLINE void LL_EXTI_EnableFallingTrig_0_31(uint32_t ExtiLine)
+{
+  SET_BIT(EXTI->FTSR1, ExtiLine);
+}
+
+/**
+  * @brief  Enable ExtiLine Falling Edge Trigger for Lines in range 32 to 63
+  * @note The configurable wakeup lines are edge-triggered. No glitch must be
+  *       generated on these lines. If a Falling edge on a configurable interrupt
+  *       line occurs during a write operation in the EXTI_FTSR register, the
+  *       pending bit is not set.
+  *       Rising and falling edge triggers can be set for
+  *       the same interrupt line. In this case, both generate a trigger
+  *       condition.
+  * @rmtoll FTSR2        FTx           LL_EXTI_EnableFallingTrig_32_63
+  * @param  ExtiLine This parameter can be a combination of the following values:
+  *         @arg @ref LL_EXTI_LINE_35
+  *         @arg @ref LL_EXTI_LINE_36
+  *         @arg @ref LL_EXTI_LINE_37
+  *         @arg @ref LL_EXTI_LINE_38
+  * @retval None
+  */
+__STATIC_INLINE void LL_EXTI_EnableFallingTrig_32_63(uint32_t ExtiLine)
+{
+  SET_BIT(EXTI->FTSR2, ExtiLine);
+}
+
+/**
+  * @brief  Disable ExtiLine Falling Edge Trigger for Lines in range 0 to 31
+  * @note The configurable wakeup lines are edge-triggered. No glitch must be
+  *       generated on these lines. If a Falling edge on a configurable interrupt
+  *       line occurs during a write operation in the EXTI_FTSR register, the
+  *       pending bit is not set.
+  *       Rising and falling edge triggers can be set for the same interrupt line.
+  *       In this case, both generate a trigger condition.
+  * @rmtoll FTSR1        FTx           LL_EXTI_DisableFallingTrig_0_31
+  * @param  ExtiLine This parameter can be a combination of the following values:
+  *         @arg @ref LL_EXTI_LINE_0
+  *         @arg @ref LL_EXTI_LINE_1
+  *         @arg @ref LL_EXTI_LINE_2
+  *         @arg @ref LL_EXTI_LINE_3
+  *         @arg @ref LL_EXTI_LINE_4
+  *         @arg @ref LL_EXTI_LINE_5
+  *         @arg @ref LL_EXTI_LINE_6
+  *         @arg @ref LL_EXTI_LINE_7
+  *         @arg @ref LL_EXTI_LINE_8
+  *         @arg @ref LL_EXTI_LINE_9
+  *         @arg @ref LL_EXTI_LINE_10
+  *         @arg @ref LL_EXTI_LINE_11
+  *         @arg @ref LL_EXTI_LINE_12
+  *         @arg @ref LL_EXTI_LINE_13
+  *         @arg @ref LL_EXTI_LINE_14
+  *         @arg @ref LL_EXTI_LINE_15
+  *         @arg @ref LL_EXTI_LINE_16
+  *         @arg @ref LL_EXTI_LINE_18
+  *         @arg @ref LL_EXTI_LINE_19
+  *         @arg @ref LL_EXTI_LINE_20
+  *         @arg @ref LL_EXTI_LINE_21
+  *         @arg @ref LL_EXTI_LINE_22
+  *         @arg @ref LL_EXTI_LINE_29
+  *         @arg @ref LL_EXTI_LINE_30
+  *         @arg @ref LL_EXTI_LINE_31
+  * @note   Please check each device line mapping for EXTI Line availability
+  * @retval None
+  */
+__STATIC_INLINE void LL_EXTI_DisableFallingTrig_0_31(uint32_t ExtiLine)
+{
+  CLEAR_BIT(EXTI->FTSR1, ExtiLine);
+}
+
+/**
+  * @brief  Disable ExtiLine Falling Edge Trigger for Lines in range 32 to 63
+  * @note The configurable wakeup lines are edge-triggered. No glitch must be
+  *       generated on these lines. If a Falling edge on a configurable interrupt
+  *       line occurs during a write operation in the EXTI_FTSR register, the
+  *       pending bit is not set.
+  *       Rising and falling edge triggers can be set for the same interrupt line.
+  *       In this case, both generate a trigger condition.
+  * @rmtoll FTSR2        FTx           LL_EXTI_DisableFallingTrig_32_63
+  * @param  ExtiLine This parameter can be a combination of the following values:
+  *         @arg @ref LL_EXTI_LINE_35
+  *         @arg @ref LL_EXTI_LINE_36
+  *         @arg @ref LL_EXTI_LINE_37
+  *         @arg @ref LL_EXTI_LINE_38
+  * @retval None
+  */
+__STATIC_INLINE void LL_EXTI_DisableFallingTrig_32_63(uint32_t ExtiLine)
+{
+  CLEAR_BIT(EXTI->FTSR2, ExtiLine);
+}
+
+/**
+  * @brief  Check if falling edge trigger is enabled for Lines in range 0 to 31
+  * @rmtoll FTSR1        FTx           LL_EXTI_IsEnabledFallingTrig_0_31
+  * @param  ExtiLine This parameter can be a combination of the following values:
+  *         @arg @ref LL_EXTI_LINE_0
+  *         @arg @ref LL_EXTI_LINE_1
+  *         @arg @ref LL_EXTI_LINE_2
+  *         @arg @ref LL_EXTI_LINE_3
+  *         @arg @ref LL_EXTI_LINE_4
+  *         @arg @ref LL_EXTI_LINE_5
+  *         @arg @ref LL_EXTI_LINE_6
+  *         @arg @ref LL_EXTI_LINE_7
+  *         @arg @ref LL_EXTI_LINE_8
+  *         @arg @ref LL_EXTI_LINE_9
+  *         @arg @ref LL_EXTI_LINE_10
+  *         @arg @ref LL_EXTI_LINE_11
+  *         @arg @ref LL_EXTI_LINE_12
+  *         @arg @ref LL_EXTI_LINE_13
+  *         @arg @ref LL_EXTI_LINE_14
+  *         @arg @ref LL_EXTI_LINE_15
+  *         @arg @ref LL_EXTI_LINE_16
+  *         @arg @ref LL_EXTI_LINE_18
+  *         @arg @ref LL_EXTI_LINE_19
+  *         @arg @ref LL_EXTI_LINE_20
+  *         @arg @ref LL_EXTI_LINE_21
+  *         @arg @ref LL_EXTI_LINE_22
+  *         @arg @ref LL_EXTI_LINE_29
+  *         @arg @ref LL_EXTI_LINE_30
+  *         @arg @ref LL_EXTI_LINE_31
+  * @note   Please check each device line mapping for EXTI Line availability
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_EXTI_IsEnabledFallingTrig_0_31(uint32_t ExtiLine)
+{
+  return ((READ_BIT(EXTI->FTSR1, ExtiLine) == (ExtiLine)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Check if falling edge trigger is enabled for Lines in range 32 to 63
+  * @rmtoll FTSR2        FTx           LL_EXTI_IsEnabledFallingTrig_32_63
+  * @param  ExtiLine This parameter can be a combination of the following values:
+  *         @arg @ref LL_EXTI_LINE_35
+  *         @arg @ref LL_EXTI_LINE_36
+  *         @arg @ref LL_EXTI_LINE_37
+  *         @arg @ref LL_EXTI_LINE_38
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_EXTI_IsEnabledFallingTrig_32_63(uint32_t ExtiLine)
+{
+  return ((READ_BIT(EXTI->FTSR2, ExtiLine) == (ExtiLine)) ? 1UL : 0UL);
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup EXTI_LL_EF_Software_Interrupt_Management Software_Interrupt_Management
+  * @{
+  */
+
+/**
+  * @brief  Generate a software Interrupt Event for Lines in range 0 to 31
+  * @note If the interrupt is enabled on this line in the EXTI_IMR1, writing a 1 to
+  *       this bit when it is at '0' sets the corresponding pending bit in EXTI_PR1
+  *       resulting in an interrupt request generation.
+  *       This bit is cleared by clearing the corresponding bit in the EXTI_PR1
+  *       register (by writing a 1 into the bit)
+  * @rmtoll SWIER1       SWIx          LL_EXTI_GenerateSWI_0_31
+  * @param  ExtiLine This parameter can be a combination of the following values:
+  *         @arg @ref LL_EXTI_LINE_0
+  *         @arg @ref LL_EXTI_LINE_1
+  *         @arg @ref LL_EXTI_LINE_2
+  *         @arg @ref LL_EXTI_LINE_3
+  *         @arg @ref LL_EXTI_LINE_4
+  *         @arg @ref LL_EXTI_LINE_5
+  *         @arg @ref LL_EXTI_LINE_6
+  *         @arg @ref LL_EXTI_LINE_7
+  *         @arg @ref LL_EXTI_LINE_8
+  *         @arg @ref LL_EXTI_LINE_9
+  *         @arg @ref LL_EXTI_LINE_10
+  *         @arg @ref LL_EXTI_LINE_11
+  *         @arg @ref LL_EXTI_LINE_12
+  *         @arg @ref LL_EXTI_LINE_13
+  *         @arg @ref LL_EXTI_LINE_14
+  *         @arg @ref LL_EXTI_LINE_15
+  *         @arg @ref LL_EXTI_LINE_16
+  *         @arg @ref LL_EXTI_LINE_18
+  *         @arg @ref LL_EXTI_LINE_19
+  *         @arg @ref LL_EXTI_LINE_20
+  *         @arg @ref LL_EXTI_LINE_21
+  *         @arg @ref LL_EXTI_LINE_22
+  *         @arg @ref LL_EXTI_LINE_29
+  *         @arg @ref LL_EXTI_LINE_30
+  *         @arg @ref LL_EXTI_LINE_31
+  * @note   Please check each device line mapping for EXTI Line availability
+  * @retval None
+  */
+__STATIC_INLINE void LL_EXTI_GenerateSWI_0_31(uint32_t ExtiLine)
+{
+  SET_BIT(EXTI->SWIER1, ExtiLine);
+}
+
+/**
+  * @brief  Generate a software Interrupt Event for Lines in range 32 to 63
+  * @note If the interrupt is enabled on this line inthe EXTI_IMR2, writing a 1 to
+  *       this bit when it is at '0' sets the corresponding pending bit in EXTI_PR2
+  *       resulting in an interrupt request generation.
+  *       This bit is cleared by clearing the corresponding bit in the EXTI_PR2
+  *       register (by writing a 1 into the bit)
+  * @rmtoll SWIER2       SWIx          LL_EXTI_GenerateSWI_32_63
+  * @param  ExtiLine This parameter can be a combination of the following values:
+  *         @arg @ref LL_EXTI_LINE_35
+  *         @arg @ref LL_EXTI_LINE_36
+  *         @arg @ref LL_EXTI_LINE_37
+  *         @arg @ref LL_EXTI_LINE_38
+  * @retval None
+  */
+__STATIC_INLINE void LL_EXTI_GenerateSWI_32_63(uint32_t ExtiLine)
+{
+  SET_BIT(EXTI->SWIER2, ExtiLine);
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup EXTI_LL_EF_Flag_Management Flag_Management
+  * @{
+  */
+
+/**
+  * @brief  Check if the ExtLine Flag is set or not for Lines in range 0 to 31
+  * @note This bit is set when the selected edge event arrives on the interrupt
+  *       line. This bit is cleared by writing a 1 to the bit.
+  * @rmtoll PR1          PIFx           LL_EXTI_IsActiveFlag_0_31
+  * @param  ExtiLine This parameter can be a combination of the following values:
+  *         @arg @ref LL_EXTI_LINE_0
+  *         @arg @ref LL_EXTI_LINE_1
+  *         @arg @ref LL_EXTI_LINE_2
+  *         @arg @ref LL_EXTI_LINE_3
+  *         @arg @ref LL_EXTI_LINE_4
+  *         @arg @ref LL_EXTI_LINE_5
+  *         @arg @ref LL_EXTI_LINE_6
+  *         @arg @ref LL_EXTI_LINE_7
+  *         @arg @ref LL_EXTI_LINE_8
+  *         @arg @ref LL_EXTI_LINE_9
+  *         @arg @ref LL_EXTI_LINE_10
+  *         @arg @ref LL_EXTI_LINE_11
+  *         @arg @ref LL_EXTI_LINE_12
+  *         @arg @ref LL_EXTI_LINE_13
+  *         @arg @ref LL_EXTI_LINE_14
+  *         @arg @ref LL_EXTI_LINE_15
+  *         @arg @ref LL_EXTI_LINE_16
+  *         @arg @ref LL_EXTI_LINE_18
+  *         @arg @ref LL_EXTI_LINE_19
+  *         @arg @ref LL_EXTI_LINE_20
+  *         @arg @ref LL_EXTI_LINE_21
+  *         @arg @ref LL_EXTI_LINE_22
+  *         @arg @ref LL_EXTI_LINE_29
+  *         @arg @ref LL_EXTI_LINE_30
+  *         @arg @ref LL_EXTI_LINE_31
+  * @note   Please check each device line mapping for EXTI Line availability
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_EXTI_IsActiveFlag_0_31(uint32_t ExtiLine)
+{
+  return ((READ_BIT(EXTI->PR1, ExtiLine) == (ExtiLine)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Check if the ExtLine Flag is set or not for  Lines in range 32 to 63
+  * @note This bit is set when the selected edge event arrives on the interrupt
+  *       line. This bit is cleared by writing a 1 to the bit.
+  * @rmtoll PR2          PIFx           LL_EXTI_IsActiveFlag_32_63
+  * @param  ExtiLine This parameter can be a combination of the following values:
+  *         @arg @ref LL_EXTI_LINE_35
+  *         @arg @ref LL_EXTI_LINE_36
+  *         @arg @ref LL_EXTI_LINE_37
+  *         @arg @ref LL_EXTI_LINE_38
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_EXTI_IsActiveFlag_32_63(uint32_t ExtiLine)
+{
+  return ((READ_BIT(EXTI->PR2, ExtiLine) == (ExtiLine)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Read ExtLine Combination Flag for Lines in range 0 to 31
+  * @note This bit is set when the selected edge event arrives on the interrupt
+  *       line. This bit is cleared by writing a 1 to the bit.
+  * @rmtoll PR1          PIFx           LL_EXTI_ReadFlag_0_31
+  * @param  ExtiLine This parameter can be a combination of the following values:
+  *         @arg @ref LL_EXTI_LINE_0
+  *         @arg @ref LL_EXTI_LINE_1
+  *         @arg @ref LL_EXTI_LINE_2
+  *         @arg @ref LL_EXTI_LINE_3
+  *         @arg @ref LL_EXTI_LINE_4
+  *         @arg @ref LL_EXTI_LINE_5
+  *         @arg @ref LL_EXTI_LINE_6
+  *         @arg @ref LL_EXTI_LINE_7
+  *         @arg @ref LL_EXTI_LINE_8
+  *         @arg @ref LL_EXTI_LINE_9
+  *         @arg @ref LL_EXTI_LINE_10
+  *         @arg @ref LL_EXTI_LINE_11
+  *         @arg @ref LL_EXTI_LINE_12
+  *         @arg @ref LL_EXTI_LINE_13
+  *         @arg @ref LL_EXTI_LINE_14
+  *         @arg @ref LL_EXTI_LINE_15
+  *         @arg @ref LL_EXTI_LINE_16
+  *         @arg @ref LL_EXTI_LINE_18
+  *         @arg @ref LL_EXTI_LINE_19
+  *         @arg @ref LL_EXTI_LINE_20
+  *         @arg @ref LL_EXTI_LINE_21
+  *         @arg @ref LL_EXTI_LINE_22
+  *         @arg @ref LL_EXTI_LINE_29
+  *         @arg @ref LL_EXTI_LINE_30
+  *         @arg @ref LL_EXTI_LINE_31
+  * @note   Please check each device line mapping for EXTI Line availability
+  * @retval @note This bit is set when the selected edge event arrives on the interrupt
+  */
+__STATIC_INLINE uint32_t LL_EXTI_ReadFlag_0_31(uint32_t ExtiLine)
+{
+  return (uint32_t)(READ_BIT(EXTI->PR1, ExtiLine));
+}
+
+/**
+  * @brief  Read ExtLine Combination Flag for  Lines in range 32 to 63
+  * @note This bit is set when the selected edge event arrives on the interrupt
+  *       line. This bit is cleared by writing a 1 to the bit.
+  * @rmtoll PR2          PIFx           LL_EXTI_ReadFlag_32_63
+  * @param  ExtiLine This parameter can be a combination of the following values:
+  *         @arg @ref LL_EXTI_LINE_35
+  *         @arg @ref LL_EXTI_LINE_36
+  *         @arg @ref LL_EXTI_LINE_37
+  *         @arg @ref LL_EXTI_LINE_38
+  * @retval @note This bit is set when the selected edge event arrives on the interrupt
+  */
+__STATIC_INLINE uint32_t LL_EXTI_ReadFlag_32_63(uint32_t ExtiLine)
+{
+  return (uint32_t)(READ_BIT(EXTI->PR2, ExtiLine));
+}
+
+/**
+  * @brief  Clear ExtLine Flags  for Lines in range 0 to 31
+  * @note This bit is set when the selected edge event arrives on the interrupt
+  *       line. This bit is cleared by writing a 1 to the bit.
+  * @rmtoll PR1          PIFx           LL_EXTI_ClearFlag_0_31
+  * @param  ExtiLine This parameter can be a combination of the following values:
+  *         @arg @ref LL_EXTI_LINE_0
+  *         @arg @ref LL_EXTI_LINE_1
+  *         @arg @ref LL_EXTI_LINE_2
+  *         @arg @ref LL_EXTI_LINE_3
+  *         @arg @ref LL_EXTI_LINE_4
+  *         @arg @ref LL_EXTI_LINE_5
+  *         @arg @ref LL_EXTI_LINE_6
+  *         @arg @ref LL_EXTI_LINE_7
+  *         @arg @ref LL_EXTI_LINE_8
+  *         @arg @ref LL_EXTI_LINE_9
+  *         @arg @ref LL_EXTI_LINE_10
+  *         @arg @ref LL_EXTI_LINE_11
+  *         @arg @ref LL_EXTI_LINE_12
+  *         @arg @ref LL_EXTI_LINE_13
+  *         @arg @ref LL_EXTI_LINE_14
+  *         @arg @ref LL_EXTI_LINE_15
+  *         @arg @ref LL_EXTI_LINE_16
+  *         @arg @ref LL_EXTI_LINE_18
+  *         @arg @ref LL_EXTI_LINE_19
+  *         @arg @ref LL_EXTI_LINE_20
+  *         @arg @ref LL_EXTI_LINE_21
+  *         @arg @ref LL_EXTI_LINE_22
+  *         @arg @ref LL_EXTI_LINE_29
+  *         @arg @ref LL_EXTI_LINE_30
+  *         @arg @ref LL_EXTI_LINE_31
+  * @note   Please check each device line mapping for EXTI Line availability
+  * @retval None
+  */
+__STATIC_INLINE void LL_EXTI_ClearFlag_0_31(uint32_t ExtiLine)
+{
+  WRITE_REG(EXTI->PR1, ExtiLine);
+}
+
+/**
+  * @brief  Clear ExtLine Flags for  Lines in range 32 to 63
+  * @note This bit is set when the selected edge event arrives on the interrupt
+  *       line. This bit is cleared by writing a 1 to the bit.
+  * @rmtoll PR2          PIFx           LL_EXTI_ClearFlag_32_63
+  * @param  ExtiLine This parameter can be a combination of the following values:
+  *         @arg @ref LL_EXTI_LINE_35
+  *         @arg @ref LL_EXTI_LINE_36
+  *         @arg @ref LL_EXTI_LINE_37
+  *         @arg @ref LL_EXTI_LINE_38
+  * @retval None
+  */
+__STATIC_INLINE void LL_EXTI_ClearFlag_32_63(uint32_t ExtiLine)
+{
+  WRITE_REG(EXTI->PR2, ExtiLine);
+}
+
+
+/**
+  * @}
+  */
+
+#if defined(USE_FULL_LL_DRIVER)
+/** @defgroup EXTI_LL_EF_Init Initialization and de-initialization functions
+  * @{
+  */
+
+uint32_t LL_EXTI_Init(LL_EXTI_InitTypeDef *EXTI_InitStruct);
+uint32_t LL_EXTI_DeInit(void);
+void LL_EXTI_StructInit(LL_EXTI_InitTypeDef *EXTI_InitStruct);
+
+
+/**
+  * @}
+  */
+#endif /* USE_FULL_LL_DRIVER */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* EXTI */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STM32L4xx_LL_EXTI_H */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/targets/stm32l432/src/device.c
+++ b/targets/stm32l432/src/device.c
@@ -509,6 +509,7 @@ int ctap_user_presence_test(uint32_t up_delay)
     // "cache" button presses for 2 seconds.
     if (millis() - __last_button_press_time < 2000)
     {
+        __last_button_press_time = 0;
         return 1;
     }
 #if SKIP_BUTTON_CHECK_WITH_DELAY

--- a/targets/stm32l432/src/device.c
+++ b/targets/stm32l432/src/device.c
@@ -38,6 +38,7 @@ void wait_for_usb_tether();
 
 
 uint32_t __90_ms = 0;
+uint32_t __last_button_press_time = 0;
 uint32_t __device_status = 0;
 uint32_t __last_update = 0;
 extern PCD_HandleTypeDef hpcd;
@@ -82,6 +83,11 @@ void TIM6_DAC_IRQHandler()
 		WTX_timer_exec();
 	}
 #endif
+}
+void EXTI0_IRQHandler(void)
+{
+    EXTI->PR1 = EXTI->PR1;
+    __last_button_press_time = millis();
 }
 
 // Global USB interrupt handler
@@ -497,6 +503,11 @@ int ctap_user_presence_test(uint32_t up_delay)
 {
     int ret;
     if (device_is_nfc() == NFC_IS_ACTIVE || _RequestComeFromNFC)
+    {
+        return 1;
+    }
+    // "cache" button presses for 2 seconds.
+    if (millis() - __last_button_press_time < 2000)
     {
         return 1;
     }

--- a/targets/stm32l432/src/init.c
+++ b/targets/stm32l432/src/init.c
@@ -850,7 +850,7 @@ void init_gpio(void)
   LL_GPIO_SetPinMode(SOLO_BUTTON_PORT,SOLO_BUTTON_PIN,LL_GPIO_MODE_INPUT);
   LL_GPIO_SetPinPull(SOLO_BUTTON_PORT,SOLO_BUTTON_PIN,LL_GPIO_PULL_UP);
 
-
+#ifndef IS_BOOTLOADER
   LL_SYSCFG_SetEXTISource(LL_SYSCFG_EXTI_PORTA, LL_SYSCFG_EXTI_LINE0);
   LL_EXTI_InitTypeDef EXTI_InitStruct;
   EXTI_InitStruct.Line_0_31 = LL_EXTI_LINE_0;   // GPIOA_0
@@ -861,6 +861,7 @@ void init_gpio(void)
   LL_EXTI_Init(&EXTI_InitStruct);
 
   NVIC_EnableIRQ(EXTI0_IRQn);
+#endif
 
 }
 

--- a/targets/stm32l432/src/init.c
+++ b/targets/stm32l432/src/init.c
@@ -20,6 +20,7 @@
 #include "stm32l4xx_ll_rng.h"
 #include "stm32l4xx_ll_spi.h"
 #include "stm32l4xx_ll_usb.h"
+#include "stm32l4xx_ll_exti.h"
 #include "stm32l4xx_hal_pcd.h"
 #include "stm32l4xx_hal.h"
 
@@ -849,20 +850,17 @@ void init_gpio(void)
   LL_GPIO_SetPinMode(SOLO_BUTTON_PORT,SOLO_BUTTON_PIN,LL_GPIO_MODE_INPUT);
   LL_GPIO_SetPinPull(SOLO_BUTTON_PORT,SOLO_BUTTON_PIN,LL_GPIO_PULL_UP);
 
-#ifdef SOLO_AMS_IRQ_PORT
-// SAVE POWER
-  // LL_AHB2_GRP1_EnableClock(LL_AHB2_GRP1_PERIPH_GPIOC);
-  // /**/
-  // LL_GPIO_InitTypeDef GPIO_InitStruct;
-  // GPIO_InitStruct.Pin = SOLO_AMS_IRQ_PIN;
-  // GPIO_InitStruct.Mode = LL_GPIO_MODE_INPUT;
-  // GPIO_InitStruct.Pull = LL_GPIO_PULL_NO;
-  // LL_GPIO_Init(SOLO_AMS_IRQ_PORT, &GPIO_InitStruct);
-  //
-  //
-  // LL_GPIO_SetPinMode(SOLO_AMS_IRQ_PORT,SOLO_AMS_IRQ_PIN,LL_GPIO_MODE_INPUT);
-  // LL_GPIO_SetPinPull(SOLO_AMS_IRQ_PORT,SOLO_AMS_IRQ_PIN,LL_GPIO_PULL_UP);
-#endif
+
+  LL_SYSCFG_SetEXTISource(LL_SYSCFG_EXTI_PORTA, LL_SYSCFG_EXTI_LINE0);
+  LL_EXTI_InitTypeDef EXTI_InitStruct;
+  EXTI_InitStruct.Line_0_31 = LL_EXTI_LINE_0;   // GPIOA_0
+  EXTI_InitStruct.Line_32_63 = LL_EXTI_LINE_NONE;
+  EXTI_InitStruct.LineCommand = ENABLE;
+  EXTI_InitStruct.Mode = LL_EXTI_MODE_IT;
+  EXTI_InitStruct.Trigger = LL_EXTI_TRIGGER_RISING;
+  LL_EXTI_Init(&EXTI_InitStruct);
+
+  NVIC_EnableIRQ(EXTI0_IRQn);
 
 }
 


### PR DESCRIPTION
Previously, Solo would only block a U2F request for about 750 milliseconds, and it's on the platform to poll repeatedly.  If the platform has a bit of a long delay between polls, this can make an annoying window you have to activate the button in.

This should solve the issue by "caching" the button press for 2 seconds.  If the last button press was within the last 2 seconds, then this counts as 1 user presence check.