### PR TITLE
refactor fido2 user presence handling & increase timeout to 29s

### DIFF
--- a/fido2/ctap.c
+++ b/fido2/ctap.c
@@ -437,7 +437,19 @@ static unsigned int get_credential_id_size(CTAP_credentialDescriptor * cred)
 static int ctap2_user_presence_test()
 {
     device_set_status(CTAPHID_STATUS_UPNEEDED);
-    return ctap_user_presence_test(CTAP2_UP_DELAY_MS);
+    int ret = ctap_user_presence_test(CTAP2_UP_DELAY_MS);
+    if ( ret > 0 )
+    {
+        return CTAP1_ERR_SUCCESS;
+    }
+    else if (ret < 0)
+    {
+        return CTAP2_ERR_KEEPALIVE_CANCEL;
+    }
+    else
+    {
+        return CTAP2_ERR_ACTION_TIMEOUT;
+    }
 }
 
 static int ctap_make_auth_data(struct rpId * rp, CborEncoder * map, uint8_t * auth_data_buf, uint32_t * len, CTAP_credInfo * credInfo)
@@ -470,15 +482,7 @@ static int ctap_make_auth_data(struct rpId * rp, CborEncoder * map, uint8_t * au
     int but;
 
     but = ctap2_user_presence_test(CTAP2_UP_DELAY_MS);
-
-    if (!but)
-    {
-        return CTAP2_ERR_OPERATION_DENIED;
-    }
-    else if (but < 0)   // Cancel
-    {
-        return CTAP2_ERR_KEEPALIVE_CANCEL;
-    }
+    check_retr(but);
     
     device_set_status(CTAPHID_STATUS_PROCESSING);
 
@@ -707,10 +711,7 @@ uint8_t ctap_make_credential(CborEncoder * encoder, uint8_t * request, int lengt
     }
     if (MC.pinAuthEmpty)
     {
-        if (!ctap2_user_presence_test(CTAP2_UP_DELAY_MS))
-        {
-                return CTAP2_ERR_OPERATION_DENIED;
-        }
+        check_retr( ctap2_user_presence_test(CTAP2_UP_DELAY_MS) );
         return ctap_is_pin_set() == 1 ? CTAP2_ERR_PIN_AUTH_INVALID : CTAP2_ERR_PIN_NOT_SET;
     }
     if ((MC.paramsParsed & MC_requiredMask) != MC_requiredMask)
@@ -1143,10 +1144,7 @@ uint8_t ctap_get_assertion(CborEncoder * encoder, uint8_t * request, int length)
 
     if (GA.pinAuthEmpty)
     {
-        if (!ctap2_user_presence_test(CTAP2_UP_DELAY_MS))
-        {
-                return CTAP2_ERR_OPERATION_DENIED;
-        }
+        check_retr( ctap2_user_presence_test(CTAP2_UP_DELAY_MS) );
         return ctap_is_pin_set() == 1 ? CTAP2_ERR_PIN_AUTH_INVALID : CTAP2_ERR_PIN_NOT_SET;
     }
     if (GA.pinAuthPresent)
@@ -1656,13 +1654,10 @@ uint8_t ctap_request(uint8_t * pkt_raw, int length, CTAP_RESPONSE * resp)
             break;
         case CTAP_RESET:
             printf1(TAG_CTAP,"CTAP_RESET\n");
-            if (ctap2_user_presence_test(CTAP2_UP_DELAY_MS))
+            status = ctap2_user_presence_test(CTAP2_UP_DELAY_MS);
+            if (status == CTAP1_ERR_SUCCESS)
             {
                 ctap_reset();
-            }
-            else
-            {
-                status = CTAP2_ERR_OPERATION_DENIED;
             }
             break;
         case GET_NEXT_ASSERTION:

--- a/fido2/ctap.h
+++ b/fido2/ctap.h
@@ -131,7 +131,7 @@
 #define PIN_LOCKOUT_ATTEMPTS        8       // Number of attempts total
 #define PIN_BOOT_ATTEMPTS           3       // number of attempts per boot
 
-#define CTAP2_UP_DELAY_MS           5000
+#define CTAP2_UP_DELAY_MS           29000
 
 typedef struct
 {

--- a/fido2/ctap_errors.h
+++ b/fido2/ctap_errors.h
@@ -49,6 +49,7 @@
 #define CTAP2_ERR_PIN_POLICY_VIOLATION      0x37
 #define CTAP2_ERR_PIN_TOKEN_EXPIRED         0x38
 #define CTAP2_ERR_REQUEST_TOO_LARGE         0x39
+#define CTAP2_ERR_ACTION_TIMEOUT            0x3A
 #define CTAP1_ERR_OTHER                     0x7F
 #define CTAP2_ERR_SPEC_LAST                 0xDF
 #define CTAP2_ERR_EXTENSION_FIRST           0xE0


### PR DESCRIPTION
Previously fido2 requests would wait 5s before failing, which is too short.  Increase to 29s.

After [29s] timeout, `CTAP2_ERR_ACTION_TIMEOUT` is returned, which is different than before.

Simplify handling of user presence in other areas