### PR TITLE
Fido2 on u2f

### DIFF
--- a/fido2/ctap.c
+++ b/fido2/ctap.c
@@ -698,7 +698,7 @@ int ctap_authenticate_credential(struct rpId * rp, CTAP_credentialDescriptor * d
             crypto_sha256_init();
             crypto_sha256_update(rp->id, rp->size);
             crypto_sha256_final(rpIdHash);
-            return u2f_authenticate_credential((struct u2f_key_handle *)&desc->credential.id, rpIdHash);
+            return u2f_authenticate_credential((struct u2f_key_handle *)&desc->credential.id, U2F_KEY_HANDLE_SIZE,rpIdHash);
         break;
         case PUB_KEY_CRED_CUSTOM:
             return is_extension_request(getAssertionState.customCredId, getAssertionState.customCredIdSize);

--- a/fido2/u2f.c
+++ b/fido2/u2f.c
@@ -210,7 +210,7 @@ int8_t u2f_authenticate_credential(struct u2f_key_handle * kh, uint8_t key_handl
             return 1;
         }
 
-    }else if (key_handle_len == U2F_KEY_HANDLE_KEY_SIZE)
+    }else if (key_handle_len == U2F_KEY_HANDLE_SIZE)
     {
         u2f_make_auth_tag(kh, appid, tag);
         if (memcmp(kh->tag, tag, U2F_KEY_HANDLE_TAG_SIZE) == 0)
@@ -222,6 +222,7 @@ int8_t u2f_authenticate_credential(struct u2f_key_handle * kh, uint8_t key_handl
     printf1(TAG_U2F, "key handle + appid not authentic\n");
     printf1(TAG_U2F, "calc tag: \n"); dump_hex1(TAG_U2F,tag, U2F_KEY_HANDLE_TAG_SIZE);
     printf1(TAG_U2F, "inp  tag: \n"); dump_hex1(TAG_U2F,kh->tag, U2F_KEY_HANDLE_TAG_SIZE);
+    return 0;
 }
 
 

--- a/fido2/u2f.h
+++ b/fido2/u2f.h
@@ -103,7 +103,7 @@ void u2f_request(struct u2f_request_apdu* req, CTAP_RESPONSE * resp);
 // @len data length
 void u2f_request_nfc(uint8_t * header, uint8_t * data, int datalen, CTAP_RESPONSE * resp);
 
-int8_t u2f_authenticate_credential(struct u2f_key_handle * kh, uint8_t * appid);
+int8_t u2f_authenticate_credential(struct u2f_key_handle * kh, uint8_t key_handle_len, uint8_t * appid);
 
 int8_t u2f_response_writeback(const uint8_t * buf, uint16_t len);
 void u2f_reset_response();

--- a/pc/device.c
+++ b/pc/device.c
@@ -108,6 +108,7 @@ int udp_recv(int fd, uint8_t * buf, int size)
         perror( "recvfrom failed" );
         exit(1);
     }
+    printf1(TAG_DUMP, ">>"); dump_hex1(TAG_DUMP, buf, length);
     return length;
 }
 
@@ -124,6 +125,8 @@ void udp_send(int fd, uint8_t * buf, int size)
         perror( "sendto failed" );
         exit(1);
     }
+
+    printf1(TAG_DUMP, "<<"); dump_hex1(TAG_DUMP, buf, size);
 }
 
 
@@ -316,7 +319,7 @@ int ctap_user_verification(uint8_t arg)
 uint32_t ctap_atomic_count(uint32_t amount)
 {
     static uint32_t counter1 = 25;
-    counter1 += amount;
+    counter1 += (amount + 1);
     return counter1;
 }
 


### PR DESCRIPTION
Previously, FIDO2 credentials will not work for U2F for Solo.  This adds support to U2F for FIDO2 registered credential IDs.