### PR TITLE
Fix docker build

### DIFF
--- a/targets/stm32l432/Makefile
+++ b/targets/stm32l432/Makefile
@@ -95,7 +95,7 @@ flashboot: bootloader.hex
 	STM32_Programmer_CLI -c port=SWD -halt  -d bootloader.hex -rst
 
 flash-firmware:
-	arm-none-eabi-size -A solo.elf
+	$(SZ) -A solo.elf
 	solo program aux enter-bootloader
 	solo program bootloader solo.hex
 

--- a/targets/stm32l432/build/bootloader.mk
+++ b/targets/stm32l432/build/bootloader.mk
@@ -66,7 +66,7 @@ all: $(TARGET).elf
 
 %.elf: $(OBJ)
 	$(CC) $^ $(HW) $(LDFLAGS) -o $@
-	arm-none-eabi-size $@
+	$(SZ) $@
 
 %.hex: %.elf
 	$(CP) -O ihex $^ $(TARGET).hex


### PR DESCRIPTION
Currently the `Makefile` script expects `arm-none-eabi-size` to be in the PATH.
The docker container does not have it.

`$(SZ)` is alias that already exist with proper path. 

So `$(SZ)` should be used instead of  `arm-none-eabi-size`.