### PR TITLE
Split docker makefile in toolchain build and firmware build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,8 @@
 *.app
 *.i*86
 *.x86_64
-*.hex
+targets/*/*.hex
+targets/*/*.sha2
 
 # Debug files
 *.dSYM/

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,15 @@ addons:
     sources:
       - ubuntu-toolchain-r-test
     packages:
-      - gcc-7
+      - gcc-8
       - cppcheck
+services:
+  - docker
 before_install:
     - sudo add-apt-repository -y ppa:team-gcc-arm-embedded/ppa
     - sudo apt-get update -q
-    - sudo apt-get install -y gcc-arm-embedded
-    - sudo apt-get install -y python3-venv
+    - sudo apt-get install -y gcc-arm-embedded python3-venv
 script:
-  - export CC=gcc-7
+  - export CC=gcc-8
   - pyenv shell 3.6.7
   - make travis

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,12 @@ RUN apt-get update -qq
 RUN apt-get install -qq bzip2 git make wget >/dev/null
 
 # 1. ARM GCC: for compilation
-RUN wget -q -O gcc.tar.bz2 https://developer.arm.com/-/media/Files/downloads/gnu-rm/8-2018q4/gcc-arm-none-eabi-8-2018-q4-major-linux.tar.bz2?revision=d830f9dd-cd4f-406d-8672-cca9210dd220?product=GNU%20Arm%20Embedded%20Toolchain,64-bit,,Linux,8-2018-q4-major
+RUN wget -q -O gcc.tar.bz2 https://developer.arm.com/-/media/Files/downloads/gnu-rm/8-2019q3/RC1.1/gcc-arm-none-eabi-8-2019-q3-update-linux.tar.bz2?revision=c34d758a-be0c-476e-a2de-af8c6e16a8a2?product=GNU%20Arm%20Embedded%20Toolchain,64-bit,,Linux,8-2019-q3-update
 #   from website
-RUN echo "f55f90d483ddb3bcf4dae5882c2094cd  gcc.tar.bz2" > gcc.md5
+RUN echo "6341f11972dac8de185646d0fbd73bfc  gcc.tar.bz2" > gcc.md5
 RUN md5sum -c gcc.md5
 #   self-generated
-RUN echo "fb31fbdfe08406ece43eef5df623c0b2deb8b53e405e2c878300f7a1f303ee52  gcc.tar.bz2" > gcc.sha256
+RUN echo "b50b02b0a16e5aad8620e9d7c31110ef285c1dde28980b1a9448b764d77d8f92  gcc.tar.bz2" > gcc.sha256
 RUN sha256sum -c gcc.sha256
 RUN tar -C /opt -xf gcc.tar.bz2
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,5 +29,4 @@ RUN ln -s /opt/conda/bin/python /usr/local/bin/python
 RUN ln -s /opt/conda/bin/pip /usr/local/bin/pip3
 RUN ln -s /opt/conda/bin/pip /usr/local/bin/pip
 
-# 3. Source code
-RUN git clone --recurse-submodules https://github.com/solokeys/solo /solo --config core.autocrlf=input
+RUN pip install -U pip && pip install -U solo-python

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,37 @@
-FROM debian:stretch-slim
+FROM debian:9.11-slim
 MAINTAINER SoloKeys <hello@solokeys.com>
 
-RUN apt-get update -qq
-RUN apt-get install -qq bzip2 git make wget >/dev/null
+# Install necessary packages
+RUN apt-get update  \
+  && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    make \
+    wget \
+    bzip2 \
+  && rm -rf /var/lib/apt/lists/*
 
-# 1. ARM GCC: for compilation
-RUN wget -q -O gcc.tar.bz2 https://developer.arm.com/-/media/Files/downloads/gnu-rm/8-2019q3/RC1.1/gcc-arm-none-eabi-8-2019-q3-update-linux.tar.bz2?revision=c34d758a-be0c-476e-a2de-af8c6e16a8a2?product=GNU%20Arm%20Embedded%20Toolchain,64-bit,,Linux,8-2019-q3-update
-#   from website
-RUN echo "6341f11972dac8de185646d0fbd73bfc  gcc.tar.bz2" > gcc.md5
-RUN md5sum -c gcc.md5
-#   self-generated
-RUN echo "b50b02b0a16e5aad8620e9d7c31110ef285c1dde28980b1a9448b764d77d8f92  gcc.tar.bz2" > gcc.sha256
-RUN sha256sum -c gcc.sha256
-RUN tar -C /opt -xf gcc.tar.bz2
+# Install ARM compiler
+RUN set -eux; \
+	url="https://developer.arm.com/-/media/Files/downloads/gnu-rm/8-2019q3/RC1.1/gcc-arm-none-eabi-8-2019-q3-update-linux.tar.bz2?revision=c34d758a-be0c-476e-a2de-af8c6e16a8a2?product=GNU%20Arm%20Embedded%20Toolchain,64-bit,,Linux,8-2019-q3-update"; \
+	wget -O gcc.tar.bz2 "$url"; \
+  echo "6341f11972dac8de185646d0fbd73bfc gcc.tar.bz2" | md5sum -c -; \
+	echo "b50b02b0a16e5aad8620e9d7c31110ef285c1dde28980b1a9448b764d77d8f92 gcc.tar.bz2" | sha256sum -c -; \
+	tar -C /opt -xf gcc.tar.bz2; \
+	rm gcc.tar.bz2;
 
-# 2. Python3.7: for solo-python (merging etc.)
-RUN wget -q -O miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-4.5.12-Linux-x86_64.sh
-#   from website
-RUN echo "866ae9dff53ad0874e1d1a60b1ad1ef8  miniconda.sh" > miniconda.md5
-RUN md5sum -c miniconda.md5
-#   self-generated
-RUN echo "e5e5b4cd2a918e0e96b395534222773f7241dc59d776db1b9f7fedfcb489157a  miniconda.sh" > miniconda.sha256
-RUN sha256sum -c miniconda.sha256
+# Python3.7: for solo-python (merging etc.)
+RUN set -eux; \
+	url="https://repo.anaconda.com/miniconda/Miniconda3-4.5.12-Linux-x86_64.sh"; \
+	wget -O miniconda.sh "$url"; \
+  echo "866ae9dff53ad0874e1d1a60b1ad1ef8 miniconda.sh" | md5sum -c -; \
+	echo "e5e5b4cd2a918e0e96b395534222773f7241dc59d776db1b9f7fedfcb489157a miniconda.sh" | sha256sum -c -; \
+	bash ./miniconda.sh -b -p /opt/conda; \
+  ln -s /opt/conda/bin/python /usr/local/bin/python3; \
+  ln -s /opt/conda/bin/python /usr/local/bin/python; \
+  ln -s /opt/conda/bin/pip /usr/local/bin/pip3; \
+  ln -s /opt/conda/bin/pip /usr/local/bin/pip; \
+	rm miniconda.sh; \
+  pip install -U pip
 
-RUN bash ./miniconda.sh -b -p /opt/conda
-RUN ln -s /opt/conda/bin/python /usr/local/bin/python3
-RUN ln -s /opt/conda/bin/python /usr/local/bin/python
-RUN ln -s /opt/conda/bin/pip /usr/local/bin/pip3
-RUN ln -s /opt/conda/bin/pip /usr/local/bin/pip
-
-RUN pip install -U pip && pip install -U solo-python
+# solo-python (Python3.7 script for merging etc.)
+RUN pip install -U solo-python

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,7 @@ docker-build:
 	docker build -t $(DOCKER_IMAGE) .
 	docker run --rm -v "$(CURDIR)/builds:/builds" \
 				    -v "$(CURDIR)/in-docker-build.sh:/in-docker-build.sh" \
+					-v "$(CURDIR):/solo" \
 				    $(DOCKER_IMAGE) "./in-docker-build.sh" $(SOLO_VERSIONISH)
 uncached-docker-build:
 	docker build --no-cache -t $(DOCKER_IMAGE) .

--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,18 @@ clean:
 full-clean: clean
 	rm -rf venv
 
+test-docker:
+	rm -rf builds/*
+	$(MAKE) uncached-docker-build-toolchain
+	# Check if there are 4 docker images/tas named "solokeys/solo-firmware-toolchain"
+	NTAGS=$$(docker images | grep -c "solokeys/solo-firmware-toolchain") && [ $$NTAGS -eq 4 ]
+	$(MAKE) docker-build-all
+	# Check that the builds were created
+	NFILES=$$(ls -l builds | grep -c "bootloader") && [ $$NFILES -eq 4 ]
+	NFILES=$$(ls -l builds | grep -c "bundle") && [ $$NFILES -eq 6 ]
+	NFILES=$$(ls -l builds | grep -c "firmware") && [ $$NFILES -eq 10 ]
+
 travis:
 	$(MAKE) test VENV=". ../../venv/bin/activate;"
+	$(MAKE) test-docker
 	$(MAKE) black

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ test: venv
 	$(MAKE) clean
 	$(MAKE) -C . main
 	$(MAKE) clean
-	$(MAKE) -C ./targets/stm32l432 test PREFIX=$(PREFIX) "VENV=$(VENV)"
+	$(MAKE) -C ./targets/stm32l432 test PREFIX=$(PREFIX) "VENV=$(VENV)" VERSION_FULL=${VERSION_FULL}
 	$(MAKE) clean
 	$(MAKE) cppcheck
 

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,8 @@ else
 endif
 LDFLAGS += $(LIBCBOR)
 
-VERSION:=$(shell git describe --abbrev=0 )
 VERSION_FULL:=$(shell git describe)
+VERSION:=$(shell python -c 'print("$(VERSION_FULL)".split("-")[0])')
 VERSION_MAJ:=$(shell python -c 'print("$(VERSION)".split(".")[0])')
 VERSION_MIN:=$(shell python -c 'print("$(VERSION)".split(".")[1])')
 VERSION_PAT:=$(shell python -c 'print("$(VERSION)".split(".")[2])')

--- a/README.md
+++ b/README.md
@@ -32,10 +32,58 @@ Check out [solokeys.com](https://solokeys.com), for options on where to buy Solo
 
 If you have a Solo for Hacker, here's how you can load your own code on it. You can find more details, including how to permanently lock it, in our [documentation](https://docs.solokeys.io/solo/building/). We support Python3.
 
+For example, if you want to turn off any blue light emission, you can edit [`led_rgb()`](https://github.com/solokeys/solo/blob/master/targets/stm32l432/src/app.h#L48) and change `LED_INIT_VALUE`
+to be a different hex color.
+
+Then recompile, load your new firmware, and enjoy a different LED color Solo.
+
+In the Hacker version, hardware is the same but the firmware is unlocked, so you can 1) load an unsigned application, or 2) entirely reflash the key. By contrast, in a regular Solo you can only upgrade to a firmware signed by SoloKeys, and flash is locked and debug disabled permanently.
+
+Hacker Solo isn't really secure so you should only use it for development. An attacker with physical access to a Solo for Hacker can reflash it following the steps above, and even a malware on your computer could possibly reflash it.
+
+## Checking out the code
 ```bash
 git clone --recurse-submodules https://github.com/solokeys/solo
 cd solo
+```
 
+If you forgot the `--recurse-submodules` while cloning, simply run `git submodule update --init --recursive`.
+
+`make update` will also checkout the latest code on `master` and submodules.
+
+## Checking out the code to build a specific version
+
+You can checkout the code to build a specific version of the firmware with:
+```
+VERSION_TO_BUILD=2.5.3
+git fetch --tags
+git checkout ${VERSION_TO_BUILD}
+git submodule update --init --recursive
+```
+
+## Installing the toolchain
+
+In order to compile ARM code, you need the ARM compiler and other things like bundling bootloader and firmware require the `solo-python` python package. Check our [documentation](https://docs.solokeys.io/solo/) for details
+
+## Installing the toolkit and compiling in Docker 
+Alternatively, you can use Docker to create a container with the toolchain.
+You can run:
+
+```bash
+# Build the toolchain container
+make docker-build-toolchain 
+
+# Build all versions of the firmware in the "builds" folder
+make docker-build-all
+```
+
+The `builds` folder will contain all the variation on the firmware in `.hex` files.
+
+## Build locally
+
+If you have the toolchain installed on your machine you can build the firmware with: 
+
+```bash
 cd targets/stm32l432
 make cbor
 make build-hacker
@@ -46,19 +94,6 @@ source venv/bin/activate
 solo program aux enter-bootloader
 solo program bootloader targets/stm32l432/solo.hex
 ```
-
-Alternatively, run `make docker-build` and use the firmware generated in `/tmp`.
-
-If you forgot the `--recurse-submodules` when cloning, simply `git submodule update --init --recursive`.
-
-For example, if you want to turn off any blue light emission, you can edit [`led_rgb()`](https://github.com/solokeys/solo/blob/master/targets/stm32l432/src/app.h#L48) and change `LED_INIT_VALUE`
-to be a different hex color.
-
-Then recompile, load your new firmware, and enjoy a different LED color Solo.
-
-In the Hacker version, hardware is the same but the firmware is unlocked, so you can 1) load an unsigned application, or 2) entirely reflash the key. By contrast, in a regular Solo you can only upgrade to a firmware signed by SoloKeys, and flash is locked and debug disabled permanently.
-
-Hacker Solo isn't really secure so you should only use it for development. An attacker with physical access to a Solo for Hacker can reflash it following the steps above, and even a malware on your computer could possibly reflash it.
 
 # Developing Solo (No Hardware Needed)
 

--- a/in-docker-build.sh
+++ b/in-docker-build.sh
@@ -1,14 +1,9 @@
 #!/bin/bash -xe
-
-version=${1:-master}
+version=$1
 
 export PREFIX=/opt/gcc-arm-none-eabi-8-2019-q3-update/bin/
 
 cd /solo/targets/stm32l432
-git fetch --tags
-git checkout ${version}
-git submodule update --init --recursive
-version=$(git describe)
 
 make cbor
 
@@ -22,7 +17,7 @@ function build() {
 
     make full-clean
 
-    make ${what}
+    make ${what} VERSION_FULL=${version}
 
     out_hex="${what}-${version}.hex"
     out_sha2="${what}-${version}.sha2"

--- a/in-docker-build.sh
+++ b/in-docker-build.sh
@@ -40,8 +40,6 @@ build firmware hacker-debug-2 solo
 build firmware secure solo
 build firmware secure-non-solokeys solo
 
-pip install -U pip
-pip install -U solo-python
 cd ${out_dir}
 bundle="bundle-hacker-${version}"
 /opt/conda/bin/solo mergehex bootloader-nonverifying-${version}.hex firmware-hacker-${version}.hex ${bundle}.hex

--- a/in-docker-build.sh
+++ b/in-docker-build.sh
@@ -2,7 +2,7 @@
 
 version=${1:-master}
 
-export PREFIX=/opt/gcc-arm-none-eabi-8-2018-q4-major/bin/
+export PREFIX=/opt/gcc-arm-none-eabi-8-2019-q3-update/bin/
 
 cd /solo/targets/stm32l432
 git fetch --tags

--- a/targets/stm32l432/Makefile
+++ b/targets/stm32l432/Makefile
@@ -2,8 +2,8 @@ ifndef DEBUG
 DEBUG=0
 endif
 
-APPMAKE=build/application.mk
-BOOTMAKE=build/bootloader.mk
+APPMAKE=build/application.mk VERSION_FULL=${VERSION_FULL} 
+BOOTMAKE=build/bootloader.mk VERSION_FULL=${VERSION_FULL} 
 
 merge_hex=solo mergehex
 

--- a/targets/stm32l432/Makefile
+++ b/targets/stm32l432/Makefile
@@ -95,7 +95,7 @@ flashboot: bootloader.hex
 	STM32_Programmer_CLI -c port=SWD -halt  -d bootloader.hex -rst
 
 flash-firmware:
-	arm-none-eabi-size -A solo.elf
+	$(SZ) -A solo.elf
 	solo program aux enter-bootloader
 	solo program bootloader solo.hex
 

--- a/targets/stm32l432/Makefile
+++ b/targets/stm32l432/Makefile
@@ -2,6 +2,7 @@ ifndef DEBUG
 DEBUG=0
 endif
 
+VERSION_FULL?=$(shell git describe)
 APPMAKE=build/application.mk VERSION_FULL=${VERSION_FULL} 
 BOOTMAKE=build/bootloader.mk VERSION_FULL=${VERSION_FULL} 
 

--- a/targets/stm32l432/build/bootloader.mk
+++ b/targets/stm32l432/build/bootloader.mk
@@ -66,7 +66,7 @@ all: $(TARGET).elf
 
 %.elf: $(OBJ)
 	$(CC) $^ $(HW) $(LDFLAGS) -o $@
-	arm-none-eabi-size $@
+	$(SZ) $@
 
 %.hex: %.elf
 	$(CP) -O ihex $^ $(TARGET).hex

--- a/targets/stm32l432/build/common.mk
+++ b/targets/stm32l432/build/common.mk
@@ -13,8 +13,8 @@ USB_LIB := lib/usbd/usbd_cdc.c lib/usbd/usbd_cdc_if.c lib/usbd/usbd_composite.c 
        lib/usbd/usbd_ctlreq.c lib/usbd/usbd_desc.c lib/usbd/usbd_hid.c \
 	   lib/usbd/usbd_ccid.c
 
-VERSION:=$(shell git describe --abbrev=0 )
-VERSION_FULL:=$(shell git describe)
+VERSION_FULL?=$(shell git describe)
+VERSION:=$(shell python -c 'print("$(VERSION_FULL)".split("-")[0])')
 VERSION_MAJ:=$(shell python -c 'print("$(VERSION)".split(".")[0])')
 VERSION_MIN:=$(shell python -c 'print("$(VERSION)".split(".")[1])')
 VERSION_PAT:=$(shell python -c 'print("$(VERSION)".split(".")[2])')


### PR DESCRIPTION
This PR include:
- Fix for docker built. The current docker build process is broken (see #329).
- Add tests for the docker build (so breaking changes will not go unnoticed again).
- Separate building the toolchain and building the firmware. Currently the flow with docker is a little messy. `Dockerfile` installs everything except the `solo-python`. At the same time checkout again the code inside the container. So in order to build the firmware we have to push the code to `origin`. This PR uses Docker to build a toolchain container  that can build the firmware but use the code on the local machine. This is done mapping the main repo inside `/solo` in the container. `make docker-build-toolchain` builds the toolchain and `make docker-build-all` builds all the different type of the firmware.
- Put the definition of `VERSION_FULL` in one place and remove the dependency on GIT in the docker. In multiple makefiles `git describe` is used to decide the `version` of the firmware. It is better to do this only once in the main `Makefile` and pass the version (`VERSION_FULL`) to the other makefiles.
- The current docker file is unoptimized and end up creating unused files in layers. This PR bring the final docker image down from about 1.2GB to 890Mb. It creates only 4 layers following docker best practices: 
  - The apt packages (cleaning the cache after installing)
  - The ARM compiler
  - Python 3.7 (miconda)
  - `solo-python` python package
- Update the ARM toolchain to the latest one: `8-2019-q3`
- Add the `.sha2` files to `.gitignore`
- It adds `makefile update` to download the latest firmware from `master`

You can test it by running `make docker-build-toolchain` and `make docker-build-all`
 