### PR TITLE
Use current user at build container runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,9 +100,10 @@ uncached-docker-build-toolchain:
 	docker tag $(DOCKER_TOOLCHAIN_IMAGE):latest $(DOCKER_TOOLCHAIN_IMAGE):${SOLO_VERSION_MAJ}
 	docker tag $(DOCKER_TOOLCHAIN_IMAGE):latest $(DOCKER_TOOLCHAIN_IMAGE):${SOLO_VERSION_MAJ}.${SOLO_VERSION_MIN}
 
-docker-build-all: 
+docker-build-all:
 	docker run --rm -v "$(CURDIR)/builds:/builds" \
 					-v "$(CURDIR):/solo" \
+					-u $(shell id -u ${USER}):$(shell id -g ${USER}) \
 				    $(DOCKER_TOOLCHAIN_IMAGE) "solo/in-docker-build.sh" ${SOLO_VERSION_FULL}
 
 CPPCHECK_FLAGS=--quiet --error-exitcode=2


### PR DESCRIPTION
Using the current user id and group removes the need to use `sudo` when
cleaning up build artifacts from the docker build stage.

Issue: #355


`builds/` Directory:
```
total 1820
drwxr-xr-x  2 jnaulty jnaulty   4096 Jan  6 01:57 ./
drwxr-xr-x 13 jnaulty jnaulty   4096 Jan  6 01:52 ../
-rw-r--r--  1 jnaulty jnaulty  44300 Jan  6 01:57 bootloader-nonverifying-3.0.1-2-gf74a77d.hex
-rw-r--r--  1 jnaulty jnaulty    111 Jan  6 01:57 bootloader-nonverifying-3.0.1-2-gf74a77d.sha2
-rw-r--r--  1 jnaulty jnaulty  57633 Jan  6 01:57 bootloader-verifying-3.0.1-2-gf74a77d.hex
-rw-r--r--  1 jnaulty jnaulty    108 Jan  6 01:57 bootloader-verifying-3.0.1-2-gf74a77d.sha2
-rw-r--r--  1 jnaulty jnaulty 221762 Jan  6 01:57 bundle-hacker-3.0.1-2-gf74a77d.hex
-rw-r--r--  1 jnaulty jnaulty    101 Jan  6 01:57 bundle-hacker-3.0.1-2-gf74a77d.sha2
-rw-r--r--  1 jnaulty jnaulty 284874 Jan  6 01:57 bundle-hacker-debug-1-3.0.1-2-gf74a77d.hex
-rw-r--r--  1 jnaulty jnaulty    109 Jan  6 01:57 bundle-hacker-debug-1-3.0.1-2-gf74a77d.sha2
-rw-r--r--  1 jnaulty jnaulty 285078 Jan  6 01:57 bundle-hacker-debug-2-3.0.1-2-gf74a77d.hex
-rw-r--r--  1 jnaulty jnaulty    109 Jan  6 01:57 bundle-hacker-debug-2-3.0.1-2-gf74a77d.sha2
-rw-r--r--  1 jnaulty jnaulty 234786 Jan  6 01:57 bundle-secure-non-solokeys-3.0.1-2-gf74a77d.hex
-rw-r--r--  1 jnaulty jnaulty    114 Jan  6 01:57 bundle-secure-non-solokeys-3.0.1-2-gf74a77d.sha2
-rw-r--r--  1 jnaulty jnaulty 180282 Jan  6 01:57 firmware-3.0.1-2-gf74a77d.hex
-rw-r--r--  1 jnaulty jnaulty     96 Jan  6 01:57 firmware-3.0.1-2-gf74a77d.sha2
-rw-r--r--  1 jnaulty jnaulty 244841 Jan  6 01:57 firmware-debug-1-3.0.1-2-gf74a77d.hex
-rw-r--r--  1 jnaulty jnaulty    104 Jan  6 01:57 firmware-debug-1-3.0.1-2-gf74a77d.sha2
-rw-r--r--  1 jnaulty jnaulty 245037 Jan  6 01:57 firmware-debug-2-3.0.1-2-gf74a77d.hex
-rw-r--r--  1 jnaulty jnaulty    104 Jan  6 01:57 firmware-debug-2-3.0.1-2-gf74a77d.sha2
-rw-r--r--  1 jnaulty jnaulty      0 Jan  6 01:48 .gitkeep

```