### PR TITLE
Fix potential version bypass in bootloader, and add command to lock flash

### DIFF
--- a/fido2/ctaphid.c
+++ b/fido2/ctaphid.c
@@ -542,6 +542,9 @@ extern void _check_ret(CborError ret, int line, const char * filename);
 
 uint8_t ctaphid_custom_command(int len, CTAP_RESPONSE * ctap_resp, CTAPHID_WRITE_BUFFER * wb);
 
+
+extern void solo_lock_if_not_already();
+
 uint8_t ctaphid_handle_packet(uint8_t * pkt_raw)
 {
     uint8_t cmd = 0;
@@ -761,6 +764,16 @@ uint8_t ctaphid_custom_command(int len, CTAP_RESPONSE * ctap_resp, CTAPHID_WRITE
             ctaphid_write(wb, NULL, 0);
             return 1;
         break;
+
+        // Remove on next release
+#if !defined(IS_BOOTLOADER) && defined(SOLO)
+        case 0x99:
+            solo_lock_if_not_already();
+            wb->bcnt = 0;
+            ctaphid_write(wb, NULL, 0);
+            return 1;
+        break;
+#endif
 
 #if !defined(IS_BOOTLOADER) && (defined(SOLO_EXPERIMENTAL))
         case CTAPHID_LOADKEY:

--- a/targets/stm32l432/bootloader/bootloader.c
+++ b/targets/stm32l432/bootloader/bootloader.c
@@ -50,7 +50,7 @@ typedef struct {
     uint8_t payload[255 - 10];
 } __attribute__((packed)) BootloaderReq;
 
-uint8_t * last_written_app_address;
+uint8_t * last_written_app_address = 0;
 
 /**
  * Erase all application pages. **APPLICATION_END_PAGE excluded**.
@@ -58,7 +58,7 @@ uint8_t * last_written_app_address;
 static void erase_application()
 {
     int page;
-    last_written_app_address = (uint8_t*) APPLICATION_START_ADDR;
+    last_written_app_address = (uint8_t*) 0;
     for(page = APPLICATION_START_PAGE; page < APPLICATION_END_PAGE; page++)
     {
         flash_erase_page(page);
@@ -113,6 +113,10 @@ int is_bootloader_disabled()
 #include "version.h"
 bool is_firmware_version_newer_or_equal()
 {
+
+    if (last_written_app_address == 0) {
+        return false;
+    }
 
     printf1(TAG_BOOT,"Current firmware version: %u.%u.%u.%u (%02x.%02x.%02x.%02x)\r\n",
           current_firmware_version.major, current_firmware_version.minor, current_firmware_version.patch, current_firmware_version.reserved,

--- a/targets/stm32l432/src/device.c
+++ b/targets/stm32l432/src/device.c
@@ -199,6 +199,20 @@ int solo_is_locked(){
     return tag == ATTESTATION_CONFIGURED_TAG && (device_settings & SOLO_FLAG_LOCKED) != 0;
 }
 
+// Locks solo flash from debugging.  Locks on next reboot.
+// This should be removed in next Solo release.
+void solo_lock_if_not_already() {
+    uint8_t buf[2048];
+
+    memmove(buf, (uint8_t*)ATTESTATION_PAGE_ADDR, 2048);
+
+    ((flash_attestation_page *)buf)->device_settings |= SOLO_FLAG_LOCKED;
+
+    flash_erase_page(ATTESTATION_PAGE);
+
+    flash_write(ATTESTATION_PAGE_ADDR, buf, 2048);
+}
+
 /** device_migrate
  * Depending on version of device, migrates:
  * * Moves attestation certificate to data segment. 

--- a/targets/stm32l432/src/init.c
+++ b/targets/stm32l432/src/init.c
@@ -146,12 +146,14 @@ void device_set_clock_rate(DEVICE_CLOCK_RATE param)
         case DEVICE_LOW_POWER_IDLE:
             SET_CLOCK_RATE0();
         break;
+#if !defined(IS_BOOTLOADER)
         case DEVICE_LOW_POWER_FAST:
             SET_CLOCK_RATE1();
         break;
         case DEVICE_FAST:
             SET_CLOCK_RATE2();
         break;
+#endif
     }
 }
 


### PR DESCRIPTION
Fixes another issue that could lead to a version bypass as pointed out by @fcremo [here](https://github.com/solokeys/solo/pull/368#issuecomment-584042556).

Additionally, added a command to force flash locking to support users locked out of the official way to secure hacker models.

To force lock flash on your device, install `solo-python` with pip3, and run `python3 -c "import solo ; d = solo.client.find() ; d.send_data_hid(0x99 ^ 0x80,'')"`.