### PR TITLE
Cbor safety

### DIFF
--- a/fido2/ctap_parse.c
+++ b/fido2/ctap_parse.c
@@ -666,8 +666,8 @@ uint8_t ctap_parse_extensions(CborValue * val, CTAP_extensions * ext)
         if (ret == CborErrorOutOfMemory)
         {
             printf2(TAG_ERR,"Error, rp map key is too large. Ignoring.\n");
-            cbor_value_advance(&map);
-            cbor_value_advance(&map);
+            check_ret( cbor_value_advance(&map) );
+            check_ret( cbor_value_advance(&map) );
             continue;
         }
         check_ret(ret);
@@ -1353,11 +1353,21 @@ uint8_t ctap_parse_client_pin(CTAP_clientPin * CP, uint8_t * request, int length
                 break;
             case CP_getKeyAgreement:
                 printf1(TAG_CP,"CP_getKeyAgreement\n");
+                if (cbor_value_get_type(&map) != CborBooleanType)
+                {
+                    printf2(TAG_ERR,"Error, expecting cbor boolean\n");
+                    return CTAP2_ERR_INVALID_CBOR_TYPE;
+                }
                 ret = cbor_value_get_boolean(&map, &CP->getKeyAgreement);
                 check_ret(ret);
                 break;
             case CP_getRetries:
                 printf1(TAG_CP,"CP_getRetries\n");
+                if (cbor_value_get_type(&map) != CborBooleanType)
+                {
+                    printf2(TAG_ERR,"Error, expecting cbor boolean\n");
+                    return CTAP2_ERR_INVALID_CBOR_TYPE;
+                }
                 ret = cbor_value_get_boolean(&map, &CP->getRetries);
                 check_ret(ret);
                 break;

--- a/targets/stm32l432/build/application.mk
+++ b/targets/stm32l432/build/application.mk
@@ -84,4 +84,5 @@ cbor:
 	cd ../../tinycbor/ && make clean
 	cd ../../tinycbor/ && make CC="$(CC)" AR=$(AR) \
 LDFLAGS="$(LDFLAGS_LIB)" \
-CFLAGS="$(CFLAGS) -Os"
+CFLAGS="$(CFLAGS) -Os  -DCBOR_PARSER_MAX_RECURSIONS=3"
+


### PR DESCRIPTION
Adds more checks to strictly check CBOR and, more importantly, limits recursion in tinycbor to a safe limit.

Based on [security audit by DoyenSec](https://blog.doyensec.com/2020/02/19/solokeys-audit.html).