### PR TITLE
Implement commands for management of resident keys

### DIFF
--- a/fido2/ctap.h
+++ b/fido2/ctap.h
@@ -17,6 +17,7 @@
 #define CTAP_RESET                  0x07
 #define GET_NEXT_ASSERTION          0x08
 #define CTAP_VENDOR_FIRST           0x40
+#define CTAP_CBOR_CRED_MGMT_PRE     0x41
 #define CTAP_VENDOR_LAST            0xBF
 
 #define MC_clientDataHash         0x01
@@ -36,6 +37,16 @@
 #define GA_options                0x05
 #define GA_pinAuth                0x06
 #define GA_pinProtocol            0x07
+
+#define CM_cmd                    0x01
+    #define CM_cmdMetadata        0x01
+    #define CM_cmdRPBegin         0x02
+    #define CM_cmdRPNext          0x03
+    #define CM_cmdRKBegin         0x04
+    #define CM_cmdRKNext          0x05
+#define CM_rpIdHash               0x02
+#define CM_pinProtocol            0x03
+#define CM_pinAuth                0x04
 
 #define CP_pinProtocol            0x01
 #define CP_subCommand             0x02
@@ -284,6 +295,16 @@ typedef struct
     CTAP_extensions extensions;
 
 } CTAP_getAssertion;
+
+typedef struct
+{
+    int cmd;
+    uint8_t rpIdHash[32];
+    uint8_t pinAuth[16];
+    uint8_t pinAuthPresent;
+    int pinProtocol;
+} CTAP_credMgmt;
+
 
 typedef struct
 {

--- a/fido2/ctap_parse.h
+++ b/fido2/ctap_parse.h
@@ -35,6 +35,7 @@ uint8_t parse_cose_key(CborValue * it, COSE_key * cose);
 
 uint8_t ctap_parse_make_credential(CTAP_makeCredential * MC, CborEncoder * encoder, uint8_t * request, int length);
 uint8_t ctap_parse_get_assertion(CTAP_getAssertion * GA, uint8_t * request, int length);
+uint8_t ctap_parse_cred_mgmt(CTAP_credMgmt * CM, uint8_t * request, int length);
 uint8_t ctap_parse_client_pin(CTAP_clientPin * CP, uint8_t * request, int length);
 uint8_t parse_credential_descriptor(CborValue * arr, CTAP_credentialDescriptor * cred);
 

--- a/fido2/log.c
+++ b/fido2/log.c
@@ -51,6 +51,7 @@ struct logtag tagtable[] = {
     {TAG_NFC,"[1;38mNFC[0m"},
     {TAG_NFC_APDU, "NAPDU"},
     {TAG_CCID, "CCID"},
+    {TAG_CM, "CRED_MGMT"},
 };
 
 

--- a/fido2/log.h
+++ b/fido2/log.h
@@ -48,6 +48,7 @@ typedef enum
     TAG_NFC      = (1 << 19),
     TAG_NFC_APDU = (1 << 20),
     TAG_CCID     = (1 << 21),
+    TAG_CM       = (1 << 22),
 
     TAG_NO_TAG   = (1UL << 30),
     TAG_FILENO   = (1UL << 31)


### PR DESCRIPTION
Implement command 0x41 which is used by OpenSSH for reading RKs. It has
the following subcommands:
 * CMD_CRED_METADATA - get number of saved/remaining RKs
 * CMD_RP_BEGIN/CMD_RP_NEXT - iterate over the saved RPs
 * CMD_RK_BEGIN/CMD_RK_NEXT - iterate over the RKs for a given RP

This fixes issue #374