### PR TITLE
Fix user presence test when pinAuth is empty

### DIFF
--- a/fido2/ctap.c
+++ b/fido2/ctap.c
@@ -736,7 +736,8 @@ uint8_t ctap_make_credential(CborEncoder * encoder, uint8_t * request, int lengt
     }
     if (MC.pinAuthEmpty)
     {
-        check_retr( ctap2_user_presence_test(CTAP2_UP_DELAY_MS) );
+        ret = ctap2_user_presence_test(CTAP2_UP_DELAY_MS);
+        check_retr(ret);
         return ctap_is_pin_set() == 1 ? CTAP2_ERR_PIN_AUTH_INVALID : CTAP2_ERR_PIN_NOT_SET;
     }
     if ((MC.paramsParsed & MC_requiredMask) != MC_requiredMask)
@@ -1169,7 +1170,8 @@ uint8_t ctap_get_assertion(CborEncoder * encoder, uint8_t * request, int length)
 
     if (GA.pinAuthEmpty)
     {
-        check_retr( ctap2_user_presence_test(CTAP2_UP_DELAY_MS) );
+        ret = ctap2_user_presence_test(CTAP2_UP_DELAY_MS);
+        check_retr(ret);
         return ctap_is_pin_set() == 1 ? CTAP2_ERR_PIN_AUTH_INVALID : CTAP2_ERR_PIN_NOT_SET;
     }
     if (GA.pinAuthPresent)


### PR DESCRIPTION
The check_retr macro is evaluating its argument twice, so when we do:

    check_retr( ctap2_user_presence_test(...) )

the user presence function is called twice and the user has to press the
button twice. This is regression introduced with commit 3b53537.