### PR TITLE
Remove CRYPTO_TRANSPORT_KEY2

### DIFF
--- a/fido2/crypto.c
+++ b/fido2/crypto.c
@@ -159,7 +159,7 @@ void crypto_sha256_hmac_final(uint8_t * key, uint32_t klen, uint8_t * hmac)
         key = master_secret;
         klen = sizeof(master_secret)/2;
     }
-    else if (key == CRYPTO_TRANSPORT_KEY2)
+    else if (key == CRYPTO_TRANSPORT_KEY)
     {
         key = transport_secret;
         klen = 32;

--- a/fido2/crypto.h
+++ b/fido2/crypto.h
@@ -36,7 +36,6 @@ void generate_private_key(uint8_t * data, int len, uint8_t * data2, int len2, ui
 void crypto_ecc256_make_key_pair(uint8_t * pubkey, uint8_t * privkey);
 void crypto_ecc256_shared_secret(const uint8_t * pubkey, const uint8_t * privkey, uint8_t * shared_secret);
 
-#define CRYPTO_TRANSPORT_KEY2            ((uint8_t*)2)
 #define CRYPTO_TRANSPORT_KEY            ((uint8_t*)1)
 #define CRYPTO_MASTER_KEY               ((uint8_t*)0)
 

--- a/fido2/ctap.c
+++ b/fido2/ctap.c
@@ -459,10 +459,10 @@ static int ctap_make_extensions(CTAP_extensions * ext, uint8_t * ext_encoder_buf
         }
 
         // Generate credRandom
-        crypto_sha256_hmac_init(CRYPTO_TRANSPORT_KEY2, 0, credRandom);
+        crypto_sha256_hmac_init(CRYPTO_TRANSPORT_KEY, 0, credRandom);
         crypto_sha256_update((uint8_t*)&ext->hmac_secret.credential->id, sizeof(CredentialId));
         crypto_sha256_update(&getAssertionState.user_verified, 1);
-        crypto_sha256_hmac_final(CRYPTO_TRANSPORT_KEY2, 0, credRandom);
+        crypto_sha256_hmac_final(CRYPTO_TRANSPORT_KEY, 0, credRandom);
 
         // Decrypt saltEnc
         crypto_aes256_init(shared_secret, NULL);


### PR DESCRIPTION
A new constant for transport_key2 was added, but no corresponding 2nd transport key exists... 
Also, the change was made only in the crypto_sha256_hmac_final function and not in crypto_sha256_hmac_init... this means that in one of the functions, (uint8_t*)1 or (uint8_t*)2 will be dereferenced and the memory there will be used as a key (!)
Either a 2nd key should be added or key 1 should be used.
This pull request removes the constant and uses key1.