### PR TITLE
Fix to multiple evaluation in htonl macro

### DIFF
--- a/fido2/extensions/extensions.c
+++ b/fido2/extensions/extensions.c
@@ -15,8 +15,10 @@
 
 #include "log.h"
 
-#define htonl(x)    (((x & 0xff) << 24) | ((x & 0xff00) << 8) \
-                    | ((x & 0xff0000) >> 8) | ((x & 0xff000000) >> 24) )
+#define htonl(x)    ((((x) &       0xff) << 24) | \
+                     (((x) &     0xff00) <<  8) | \
+                     (((x) &   0xff0000) >>  8) | \
+                     (((x) & 0xff000000) >> 24))
 
 int is_extension_request(uint8_t * kh, int len)
 {
@@ -65,7 +67,8 @@ int16_t bridge_u2f_to_extensions(uint8_t * _chal, uint8_t * _appid, uint8_t klen
     uint8_t sig[72];
     if (extension_needs_atomic_count(klen, keyh))
     {
-        count = htonl(ctap_atomic_count(0));
+        count = ctap_atomic_count(0);
+        count = htonl(count);
     }
     else
     {


### PR DESCRIPTION
The htonl could also be applied after the if-else, but for the "10" constant, it's better to do it at compile time / not necessary to do at run time