### PR TITLE
POC: add ed25519 support based on libsodium (PC) or salty (solo).

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "crypto/cifra"]
 	path = crypto/cifra
 	url = https://github.com/solokeys/cifra.git
+[submodule "crypto/salty"]
+	path = crypto/salty
+	url = https://github.com/ycrypto/salty.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ addons:
     packages:
       - gcc-8
       - cppcheck
+      - libsodium-dev
 services:
   - docker
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,21 @@ addons:
 services:
   - docker
 before_install:
-    - sudo add-apt-repository -y ppa:team-gcc-arm-embedded/ppa
-    - sudo apt-get update -q
-    - sudo apt-get install -y gcc-arm-embedded python3-venv
+  - sudo add-apt-repository -y ppa:team-gcc-arm-embedded/ppa
+  - sudo apt-get update -q
+  - sudo apt-get install -y gcc-arm-embedded python3-venv
+  - >
+    set -eu;
+    url="https://raw.githubusercontent.com/rust-lang/rustup/1.22.1/rustup-init.sh";
+    wget -O rustup-init.sh "$url";
+    echo "b273275cf4d83cb6b991c1090baeca54  rustup-init.sh" | md5sum -c -;
+    echo "8928261388c8fae83bfd79b08d9030dfe21d17a8b59e9dcabda779213f6a3d14  rustup-init.sh" | sha256sum -c -;
+    bash ./rustup-init.sh --profile=minimal -y -t thumbv7em-none-eabihf;
+    rm rustup-init.sh;
+    set +eu
+
 script:
   - export CC=gcc-8
+  - source ${HOME}/.cargo/env
   - pyenv shell 3.6.7
   - make travis

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ RUN apt-get update  \
     wget \
     bzip2 \
     git \
+    gcc \
+    libc6-dev \
   && rm -rf /var/lib/apt/lists/*
 
 # Install ARM compiler
@@ -36,3 +38,15 @@ RUN set -eux; \
 
 # solo-python (Python3.7 script for merging etc.)
 RUN pip install -U solo-python
+
+# Rust for salty
+ENV RUSTUP_HOME=/rust/rustup
+ENV CARGO_HOME=/rust/cargo
+RUN set -eux; \
+    url="https://raw.githubusercontent.com/rust-lang/rustup/1.22.1/rustup-init.sh"; \
+    wget -O rustup-init.sh "$url"; \
+    echo "b273275cf4d83cb6b991c1090baeca54  rustup-init.sh" | md5sum -c -; \
+    echo "8928261388c8fae83bfd79b08d9030dfe21d17a8b59e9dcabda779213f6a3d14  rustup-init.sh" | sha256sum -c -; \
+    bash ./rustup-init.sh --profile=minimal -y -t thumbv7em-none-eabihf; \
+    rm rustup-init.sh; \
+    chmod -R go+rwX /rust

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ ifeq ($(shell uname -s),Darwin)
 else
   export LDFLAGS = -Wl,--gc-sections
 endif
-LDFLAGS += $(LIBSOLO) $(LIBCBOR)
+LDFLAGS += $(LIBSOLO) $(LIBCBOR) -lsodium
 
 
 CFLAGS = -O2 -fdata-sections -ffunction-sections -g

--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,11 @@ all: main
 tinycbor/Makefile crypto/tiny-AES-c/aes.c:
 	git submodule update --init
 
-.PHONY: cbor
+.PHONY: cbor cborclean
 cbor: $(LIBCBOR)
+
+cborclean:
+	cd tinycbor && $(MAKE) clean
 
 $(LIBCBOR):
 	cd tinycbor/ && $(MAKE)  LDFLAGS='' -j8
@@ -54,6 +57,7 @@ version:
 	@git describe
 
 test: venv
+	$(MAKE) cborclean
 	$(MAKE) clean
 	$(MAKE) -C . main
 	$(MAKE) clean

--- a/fido2/cose_key.h
+++ b/fido2/cose_key.h
@@ -13,10 +13,14 @@
 #define COSE_KEY_LABEL_X        -2
 #define COSE_KEY_LABEL_Y        -3
 
+#define COSE_KEY_KTY_OKP        1
 #define COSE_KEY_KTY_EC2        2
+
 #define COSE_KEY_CRV_P256       1
+#define COSE_KEY_CRV_ED25519    6
 
 #define COSE_ALG_ES256            -7
+#define COSE_ALG_EDDSA            -8
 #define COSE_ALG_ECDH_ES_HKDF_256 -25
 
 #endif

--- a/fido2/crypto.c
+++ b/fido2/crypto.c
@@ -370,7 +370,7 @@ void crypto_ed25519_derive_public_key(uint8_t * data, int len, uint8_t * x)
     uint8_t seed[salty_SECRETKEY_SEED_LENGTH];
 
     generate_private_key(data, len, NULL, 0, seed);
-    salty_public_key(seed, x);
+    salty_public_key(&seed, (uint8_t (*)[salty_PUBLICKEY_SERIALIZED_LENGTH])x);
 
 #else
 
@@ -430,7 +430,8 @@ void crypto_ed25519_sign(uint8_t * data1, int len1, uint8_t * data2, int len2, u
 #if defined(STM32L432xx)
 
     // TODO: check that correct load_key() had been called?
-    salty_sign(_signing_key, data, len, sig);
+    salty_sign((uint8_t (*)[salty_SECRETKEY_SEED_LENGTH])_signing_key, data, len,
+            (uint8_t (*)[salty_SIGNATURE_SERIALIZED_LENGTH])sig);
 
 #else
 

--- a/fido2/crypto.c
+++ b/fido2/crypto.c
@@ -409,8 +409,24 @@ void crypto_ed25519_load_key(uint8_t * data, int len)
 #endif
 }
 
-void crypto_ed25519_sign(uint8_t * data, int len, uint8_t * sig)
+void crypto_ed25519_sign(uint8_t * data1, int len1, uint8_t * data2, int len2, uint8_t * sig)
 {
+    // ed25519 signature APIs need the message at once (by design!) and in one
+    // contiguous buffer (could be changed).
+
+    // 512 is an arbitrary sanity limit, could be less
+    if (len1 < 0 || len2 < 0 || len1 > 512 || len2 > 512)
+    {
+        memset(sig, 0, 64); // ed25519 signature len is 64 bytes
+        return;
+    }
+    // XXX: dynamically sized allocation on the stack
+    const int len = len1 + len2; // 0 <= len <= 1024
+    uint8_t data[len1 + len2];
+
+    memcpy(data,        data1, len1);
+    memcpy(data + len1, data2, len2);
+
 #if defined(STM32L432xx)
 
     // TODO: check that correct load_key() had been called?

--- a/fido2/crypto.h
+++ b/fido2/crypto.h
@@ -32,7 +32,7 @@ void crypto_ecc256_sign(uint8_t * data, int len, uint8_t * sig);
 void crypto_ecdsa_sign(uint8_t * data, int len, uint8_t * sig, int MBEDTLS_ECP_ID);
 
 void crypto_ed25519_derive_public_key(uint8_t * data, int len, uint8_t * x);
-void crypto_ed25519_sign(uint8_t * data1, int len1, uint8_t * sig);
+void crypto_ed25519_sign(uint8_t * data1, int len1, uint8_t * data2, int len2, uint8_t * sig);
 void crypto_ed25519_load_key(uint8_t * data, int len);
 
 void generate_private_key(uint8_t * data, int len, uint8_t * data2, int len2, uint8_t * privkey);

--- a/fido2/crypto.h
+++ b/fido2/crypto.h
@@ -31,6 +31,9 @@ void crypto_load_external_key(uint8_t * key, int len);
 void crypto_ecc256_sign(uint8_t * data, int len, uint8_t * sig);
 void crypto_ecdsa_sign(uint8_t * data, int len, uint8_t * sig, int MBEDTLS_ECP_ID);
 
+void crypto_ed25519_derive_public_key(uint8_t * data, int len, uint8_t * x);
+void crypto_ed25519_sign(uint8_t * data1, int len1, uint8_t * sig);
+void crypto_ed25519_load_key(uint8_t * data, int len);
 
 void generate_private_key(uint8_t * data, int len, uint8_t * data2, int len2, uint8_t * privkey);
 void crypto_ecc256_make_key_pair(uint8_t * pubkey, uint8_t * privkey);

--- a/fido2/ctap.c
+++ b/fido2/ctap.c
@@ -793,9 +793,7 @@ int ctap_calculate_signature(uint8_t * data, int datalen, uint8_t * clientDataHa
     // calculate attestation sig
     if (alg == COSE_ALG_EDDSA)
     {
-        // ED25519 signing needs message in one chunk
-        memmove(data + datalen, clientDataHash, CLIENT_DATA_HASH_SIZE);
-        crypto_ed25519_sign(data, datalen + CLIENT_DATA_HASH_SIZE, sigder); // not DER, just plain binary!
+        crypto_ed25519_sign(data, datalen, clientDataHash, CLIENT_DATA_HASH_SIZE, sigder); // not DER, just plain binary!
         return 64;
     }
     else
@@ -903,7 +901,7 @@ uint8_t ctap_make_credential(CborEncoder * encoder, uint8_t * request, int lengt
     CTAP_makeCredential MC;
     int ret;
     unsigned int i;
-    uint8_t auth_data_buf[310 + CLIENT_DATA_HASH_SIZE];
+    uint8_t auth_data_buf[310];
     CTAP_credentialDescriptor * excl_cred = (CTAP_credentialDescriptor *) auth_data_buf;
     uint8_t * sigbuf = auth_data_buf + 32;
     uint8_t * sigder = auth_data_buf + 32 + 64;

--- a/fido2/ctap.c
+++ b/fido2/ctap.c
@@ -41,13 +41,13 @@ struct _getAssertionState getAssertionState;
 // Generate a mask to keep the confidentiality of the "metadata" field in the credential ID.
 // Mask = hmac(device-secret, 14-random-bytes-in-credential-id)
 // Masked_output = Mask ^ metadata
-static void add_masked_metadata_for_credential(CredentialId * credential, uint32_t cred_protect){
+static void add_masked_metadata_for_credential(CredentialId * credential, uint32_t metadata){
     uint8_t mask[32];
     crypto_sha256_hmac_init(CRYPTO_TRANSPORT_KEY, 0, mask);
     crypto_sha256_update(credential->entropy.nonce, CREDENTIAL_NONCE_SIZE - 4);
     crypto_sha256_hmac_final(CRYPTO_TRANSPORT_KEY,0, mask);
 
-    credential->entropy.metadata.value = *((uint32_t*)mask) ^ cred_protect;
+    credential->entropy.metadata.value = *((uint32_t*)mask) ^ metadata;
 }
 
 static uint32_t read_metadata_from_masked_credential(CredentialId * credential){
@@ -59,11 +59,29 @@ static uint32_t read_metadata_from_masked_credential(CredentialId * credential){
     return credential->entropy.metadata.value ^ *((uint32_t*)mask);
 }
 
-
-
-uint8_t check_credential_metadata(CredentialId * credential, uint8_t is_verified, uint8_t is_from_credid_list)
+static uint32_t read_cred_protect_from_masked_credential(CredentialId * credential)
 {
-    uint32_t cred_protect = read_metadata_from_masked_credential(credential);
+    return read_metadata_from_masked_credential(credential) & 0xffffU;
+}
+
+static int32_t read_cose_alg_from_masked_credential(CredentialId * credential)
+{
+    uint8_t  alg = (read_metadata_from_masked_credential(credential) >> 16) & 0xffU;
+
+    switch (alg)
+    {
+        default: // what else?
+        case CREDID_ALG_ES256:
+            return COSE_ALG_ES256;
+        case CREDID_ALG_EDDSA:
+            return COSE_ALG_EDDSA;
+    }
+}
+
+static uint8_t check_credential_metadata(CredentialId * credential, uint8_t is_verified, uint8_t is_from_credid_list)
+{
+    uint32_t cred_protect = read_cred_protect_from_masked_credential(credential);
+
     switch (cred_protect){
         case EXT_CRED_PROTECT_OPTIONAL_WITH_CREDID:
             if (!is_from_credid_list) {
@@ -80,6 +98,7 @@ uint8_t check_credential_metadata(CredentialId * credential, uint8_t is_verified
             }
         break;
     }
+
     return 0;
 }
 
@@ -250,7 +269,7 @@ uint8_t ctap_get_info(CborEncoder * encoder)
             check_ret(ret);
         }
 
-        ret = cbor_encode_uint(&map, 0x08); // maxCredentialIdLength 
+        ret = cbor_encode_uint(&map, 0x08); // maxCredentialIdLength
         check_ret(ret);
         {
             ret = cbor_encode_uint(&map, 128);
@@ -271,14 +290,14 @@ static int ctap_add_cose_key(CborEncoder * cose_key, uint8_t * x, uint8_t * y, u
     int ret;
     CborEncoder map;
 
-    ret = cbor_encoder_create_map(cose_key, &map, 5);
+    ret = cbor_encoder_create_map(cose_key, &map, algtype != COSE_ALG_EDDSA? 5 : 4);
     check_ret(ret);
 
 
     {
         ret = cbor_encode_int(&map, COSE_KEY_LABEL_KTY);
         check_ret(ret);
-        ret = cbor_encode_int(&map, COSE_KEY_KTY_EC2);
+        ret = cbor_encode_int(&map, algtype != COSE_ALG_EDDSA? COSE_KEY_KTY_EC2 : COSE_KEY_KTY_OKP);
         check_ret(ret);
     }
 
@@ -292,7 +311,7 @@ static int ctap_add_cose_key(CborEncoder * cose_key, uint8_t * x, uint8_t * y, u
     {
         ret = cbor_encode_int(&map, COSE_KEY_LABEL_CRV);
         check_ret(ret);
-        ret = cbor_encode_int(&map, COSE_KEY_CRV_P256);
+        ret = cbor_encode_int(&map, algtype != COSE_ALG_EDDSA? COSE_KEY_CRV_P256: COSE_KEY_CRV_ED25519);
         check_ret(ret);
     }
 
@@ -304,6 +323,7 @@ static int ctap_add_cose_key(CborEncoder * cose_key, uint8_t * x, uint8_t * y, u
         check_ret(ret);
     }
 
+    if (algtype != COSE_ALG_EDDSA)
     {
         ret = cbor_encode_int(&map, COSE_KEY_LABEL_Y);
         check_ret(ret);
@@ -330,6 +350,11 @@ static int ctap_generate_cose_key(CborEncoder * cose_key, uint8_t * hmac_input, 
         case COSE_ALG_ES256:
             if (device_is_nfc() == NFC_IS_ACTIVE) device_set_clock_rate(DEVICE_LOW_POWER_FAST);
             crypto_ecc256_derive_public_key(hmac_input, len, x, y);
+            if (device_is_nfc() == NFC_IS_ACTIVE) device_set_clock_rate(DEVICE_LOW_POWER_IDLE);
+            break;
+        case COSE_ALG_EDDSA:
+            if (device_is_nfc() == NFC_IS_ACTIVE) device_set_clock_rate(DEVICE_LOW_POWER_FAST);
+            crypto_ed25519_derive_public_key(hmac_input, len, x);
             if (device_is_nfc() == NFC_IS_ACTIVE) device_set_clock_rate(DEVICE_LOW_POWER_IDLE);
             break;
         default:
@@ -627,8 +652,8 @@ static int ctap_make_auth_data(struct rpId * rp, CborEncoder * map, uint8_t * au
         check_retr(but);
         authData->head.flags = (1 << 0);        // User presence
     }
-    
-    
+
+
     device_set_status(CTAPHID_STATUS_PROCESSING);
 
     authData->head.flags |= (ctap_is_pin_set() << 2);
@@ -648,7 +673,9 @@ static int ctap_make_auth_data(struct rpId * rp, CborEncoder * map, uint8_t * au
         memset((uint8_t*)&authData->attest.id, 0, sizeof(CredentialId));
 
         ctap_generate_rng(authData->attest.id.entropy.nonce, CREDENTIAL_NONCE_SIZE);
-        add_masked_metadata_for_credential(&authData->attest.id, extensions->cred_protect);
+
+        uint8_t alg = credInfo->COSEAlgorithmIdentifier == COSE_ALG_EDDSA? CREDID_ALG_EDDSA : CREDID_ALG_ES256;
+        add_masked_metadata_for_credential(&authData->attest.id, extensions->cred_protect | (alg << 16));
 
         authData->attest.id.count = count;
 
@@ -755,22 +782,32 @@ int ctap_encode_der_sig(const uint8_t * const in_sigbuf, uint8_t * const out_sig
 }
 
 // require load_key prior to this
-// @data data to hash before signature
+// @data data to hash before signature, MUST have room to append clientDataHash for ED25519
 // @clientDataHash for signature
 // @tmp buffer for hash.  (can be same as data if data >= 32 bytes)
 // @sigbuf OUT location to deposit signature (must be 64 bytes)
 // @sigder OUT location to deposit der signature (must be 72 bytes)
 // @return length of der signature
-int ctap_calculate_signature(uint8_t * data, int datalen, uint8_t * clientDataHash, uint8_t * hashbuf, uint8_t * sigbuf, uint8_t * sigder)
+int ctap_calculate_signature(uint8_t * data, int datalen, uint8_t * clientDataHash, uint8_t * hashbuf, uint8_t * sigbuf, uint8_t * sigder, int32_t alg)
 {
     // calculate attestation sig
-    crypto_sha256_init();
-    crypto_sha256_update(data, datalen);
-    crypto_sha256_update(clientDataHash, CLIENT_DATA_HASH_SIZE);
-    crypto_sha256_final(hashbuf);
+    if (alg == COSE_ALG_EDDSA)
+    {
+        // ED25519 signing needs message in one chunk
+        memmove(data + datalen, clientDataHash, CLIENT_DATA_HASH_SIZE);
+        crypto_ed25519_sign(data, datalen + CLIENT_DATA_HASH_SIZE, sigder); // not DER, just plain binary!
+        return 64;
+    }
+    else
+    {
+        crypto_sha256_init();
+        crypto_sha256_update(data, datalen);
+        crypto_sha256_update(clientDataHash, CLIENT_DATA_HASH_SIZE);
+        crypto_sha256_final(hashbuf);
 
-    crypto_ecc256_sign(hashbuf, 32, sigbuf);
-    return ctap_encode_der_sig(sigbuf,sigder);
+        crypto_ecc256_sign(hashbuf, 32, sigbuf);
+        return ctap_encode_der_sig(sigbuf,sigder);
+    }
 }
 
 uint8_t ctap_add_attest_statement(CborEncoder * map, uint8_t * sigder, int len)
@@ -783,7 +820,7 @@ uint8_t ctap_add_attest_statement(CborEncoder * map, uint8_t * sigder, int len)
         return CTAP2_ERR_PROCESSING;
     }
     device_attestation_read_cert_der(cert);
-    
+
     CborEncoder stmtmap;
     CborEncoder x5carr;
 
@@ -866,7 +903,7 @@ uint8_t ctap_make_credential(CborEncoder * encoder, uint8_t * request, int lengt
     CTAP_makeCredential MC;
     int ret;
     unsigned int i;
-    uint8_t auth_data_buf[310];
+    uint8_t auth_data_buf[310 + CLIENT_DATA_HASH_SIZE];
     CTAP_credentialDescriptor * excl_cred = (CTAP_credentialDescriptor *) auth_data_buf;
     uint8_t * sigbuf = auth_data_buf + 32;
     uint8_t * sigder = auth_data_buf + 32 + 64;
@@ -975,7 +1012,7 @@ uint8_t ctap_make_credential(CborEncoder * encoder, uint8_t * request, int lengt
     }
 
     crypto_ecc256_load_attestation_key();
-    int sigder_sz = ctap_calculate_signature(auth_data_buf, auth_data_sz, MC.clientDataHash, auth_data_buf, sigbuf, sigder);
+    int sigder_sz = ctap_calculate_signature(auth_data_buf, auth_data_sz, MC.clientDataHash, auth_data_buf, sigbuf, sigder, COSE_ALG_ES256);
     printf1(TAG_MC,"der sig [%d]: ", sigder_sz); dump_hex1(TAG_MC, sigder, sigder_sz);
 
     ret = ctap_add_attest_statement(&map, sigder, sigder_sz);
@@ -1136,14 +1173,14 @@ int ctap_filter_invalid_credentials(CTAP_getAssertion * GA)
         else
         {
 
-            int protection_status = 
+            int protection_status =
                 check_credential_metadata(&GA->creds[i].credential.id, getAssertionState.user_verified, 1);
 
             if (protection_status != 0) {
                 printf1(TAG_GREEN,"skipping protected wrapped credential.\r\n");
                 GA->creds[i].credential.id.count = 0;      // invalidate
             }
-            else 
+            else
             {
                 // add user info if it exists
                 add_existing_user_info(&GA->creds[i]);
@@ -1170,7 +1207,7 @@ int ctap_filter_invalid_credentials(CTAP_getAssertion * GA)
 
             printf1(TAG_GREEN, "rpIdHash%d: ", i);  dump_hex1(TAG_GREEN, rk.id.rpIdHash, 32);
 
-            int protection_status = 
+            int protection_status =
                 check_credential_metadata(&rk.id, getAssertionState.user_verified, 0);
 
             if (protection_status != 0) {
@@ -1200,8 +1237,8 @@ int ctap_filter_invalid_credentials(CTAP_getAssertion * GA)
 }
 
 
-static int8_t save_credential_list( uint8_t * clientDataHash, 
-                                    CTAP_credentialDescriptor * creds, 
+static int8_t save_credential_list( uint8_t * clientDataHash,
+                                    CTAP_credentialDescriptor * creds,
                                     uint32_t count,
                                     CTAP_extensions * extensions)
 {
@@ -1258,7 +1295,15 @@ uint8_t ctap_end_get_assertion(CborEncoder * map, CTAP_credentialDescriptor * cr
     }
 
     unsigned int cred_size = get_credential_id_size(cred->type);
-    crypto_ecc256_load_key((uint8_t*)&cred->credential.id, cred_size, NULL, 0);
+    int32_t cose_alg = read_cose_alg_from_masked_credential(&cred->credential.id);
+    if (cose_alg == COSE_ALG_EDDSA)
+    {
+        crypto_ed25519_load_key((uint8_t*)&cred->credential.id, cred_size);
+    }
+    else
+    {
+        crypto_ecc256_load_key((uint8_t*)&cred->credential.id, cred_size, NULL, 0);
+    }
 
 #ifdef ENABLE_U2F_EXTENSIONS
     if ( extend_fido2(&cred->credential.id, sigder) )
@@ -1268,8 +1313,10 @@ uint8_t ctap_end_get_assertion(CborEncoder * map, CTAP_credentialDescriptor * cr
     else
 #endif
     {
-        sigder_sz = ctap_calculate_signature(auth_data_buf, auth_data_buf_sz, clientDataHash, auth_data_buf, sigbuf, sigder);
+        sigder_sz = ctap_calculate_signature(auth_data_buf, auth_data_buf_sz, clientDataHash, auth_data_buf, sigbuf, sigder, cose_alg);
     }
+
+    printf1(TAG_GREEN, "sigder_sz = %d\n", sigder_sz);
 
     {
         ret = cbor_encode_int(map, RESP_signature);  // 3
@@ -1341,9 +1388,9 @@ uint8_t ctap_get_next_assertion(CborEncoder * encoder)
         }
     }
 
-    ret = ctap_end_get_assertion(&map, cred, 
-                                (uint8_t *)&getAssertionState.buf.authData, 
-                                sizeof(CTAP_authDataHeader) + ext_encoder_buf_size, 
+    ret = ctap_end_get_assertion(&map, cred,
+                                (uint8_t *)&getAssertionState.buf.authData,
+                                sizeof(CTAP_authDataHeader) + ext_encoder_buf_size,
                                 getAssertionState.clientDataHash);
 
     check_retr(ret);
@@ -1428,11 +1475,13 @@ uint8_t ctap_cred_rk(CborEncoder * encoder, int rk_ind, int rk_count)
     ctap_load_rk(rk_ind, &rk);
 
     uint32_t cred_protect = read_metadata_from_masked_credential(&rk.id);
-    if ( cred_protect == 0 || cred_protect > 3 ) 
+    if ( cred_protect == 0 || cred_protect > 3 )
     {
         // Take default value of userVerificationOptional
         cred_protect = EXT_CRED_PROTECT_OPTIONAL;
     }
+
+    int32_t cose_alg = read_cose_alg_from_masked_credential(&rk.id);
 
     CborEncoder map;
     size_t map_size = rk_count > 0 ? 5 : 4;
@@ -1456,7 +1505,7 @@ uint8_t ctap_cred_rk(CborEncoder * encoder, int rk_ind, int rk_count)
     ret = cbor_encode_int(&map, 8);
     check_ret(ret);
     {
-        ctap_generate_cose_key(&map, (uint8_t*)&rk.id, sizeof(CredentialId), PUB_KEY_CRED_PUB_KEY, COSE_ALG_ES256);
+        ctap_generate_cose_key(&map, (uint8_t*)&rk.id, sizeof(CredentialId), PUB_KEY_CRED_PUB_KEY, cose_alg);
     }
 
     if (rk_count > 0)
@@ -1479,8 +1528,8 @@ uint8_t ctap_cred_rk(CborEncoder * encoder, int rk_ind, int rk_count)
 
 uint8_t ctap_cred_mgmt_pinauth(CTAP_credMgmt *CM)
 {
-    if (CM->cmd != CM_cmdMetadata && 
-        CM->cmd != CM_cmdRPBegin && 
+    if (CM->cmd != CM_cmdMetadata &&
+        CM->cmd != CM_cmdRPBegin &&
         CM->cmd != CM_cmdRKBegin &&
         CM->cmd != CM_cmdRKDelete)
     {
@@ -1548,7 +1597,7 @@ static int scan_for_next_rp(int index){
         occurs_previously = 0;
 
         index++;
-        if ((unsigned int)index >= ctap_rk_size()) 
+        if ((unsigned int)index >= ctap_rk_size())
         {
             return -1;
         }
@@ -1598,7 +1647,7 @@ static int scan_for_next_rk(int index, uint8_t * initialRpIdHash){
     do
     {
         index++;
-        if ((unsigned int)index >= ctap_rk_size()) 
+        if ((unsigned int)index >= ctap_rk_size())
         {
             return -1;
         }
@@ -1870,8 +1919,8 @@ uint8_t ctap_get_assertion(CborEncoder * encoder, uint8_t * request, int length)
     ret = cbor_encoder_close_container(encoder, &map);
     check_ret(ret);
 
-    ret = save_credential_list( GA.clientDataHash, 
-                                GA.creds + 1 /* skip first credential*/, 
+    ret = save_credential_list( GA.clientDataHash,
+                                GA.creds + 1 /* skip first credential*/,
                                 validCredCount - 1,
                                 &GA.extensions);
     check_retr(ret);
@@ -2365,7 +2414,7 @@ static void ctap_state_init()
 
 /** Overwrite master secret from external source.
  * @param keybytes an array of KEY_SPACE_BYTES length.
- * 
+ *
  * This function should only be called from a privilege mode.
 */
 void ctap_load_external_keys(uint8_t * keybytes){

--- a/fido2/ctap.h
+++ b/fido2/ctap.h
@@ -360,10 +360,10 @@ typedef struct
 
 
 struct _getAssertionState {
-    // Room for both authData struct and extensions + clientDataHash for efficient ED25519 signature generation
+    // Room for both authData struct and extensions
     struct {
         CTAP_authDataHeader authData;
-        uint8_t extensions[80 + CLIENT_DATA_HASH_SIZE];
+        uint8_t extensions[80];
     } __attribute__((packed)) buf;
     CTAP_extensions extensions;
     uint8_t clientDataHash[CLIENT_DATA_HASH_SIZE];

--- a/fido2/ctap.h
+++ b/fido2/ctap.h
@@ -78,6 +78,9 @@
 #define EXT_CRED_PROTECT_OPTIONAL_WITH_CREDID   0x02
 #define EXT_CRED_PROTECT_REQUIRED               0x03
 
+#define CREDID_ALG_ES256            0x0
+#define CREDID_ALG_EDDSA            0x1
+
 #define RESP_versions               0x1
 #define RESP_extensions             0x2
 #define RESP_aaguid                 0x3
@@ -357,10 +360,10 @@ typedef struct
 
 
 struct _getAssertionState {
-    // Room for both authData struct and extensions
+    // Room for both authData struct and extensions + clientDataHash for efficient ED25519 signature generation
     struct {
         CTAP_authDataHeader authData;
-        uint8_t extensions[80];
+        uint8_t extensions[80 + CLIENT_DATA_HASH_SIZE];
     } __attribute__((packed)) buf;
     CTAP_extensions extensions;
     uint8_t clientDataHash[CLIENT_DATA_HASH_SIZE];

--- a/fido2/ctap_parse.c
+++ b/fido2/ctap_parse.c
@@ -256,7 +256,7 @@ static int pub_key_cred_param_supported(uint8_t cred, int32_t alg)
 {
     if (cred == PUB_KEY_CRED_PUB_KEY)
     {
-        if (alg == COSE_ALG_ES256)
+        if (alg == COSE_ALG_ES256 || alg == COSE_ALG_EDDSA)
         {
             return  CREDENTIAL_IS_SUPPORTED;
         }
@@ -1025,7 +1025,7 @@ static uint8_t parse_cred_mgmt_subcommandparams(CborValue * val, CTAP_credMgmt *
 
     ret = cbor_value_enter_container(val,&map);
     check_ret(ret);
-    
+
     const uint8_t * start_byte = cbor_value_get_next_byte(&map) - 1;
 
     ret = cbor_value_get_map_length(val, &map_length);

--- a/in-docker-build.sh
+++ b/in-docker-build.sh
@@ -2,11 +2,13 @@
 version=$1
 
 export PREFIX=/opt/gcc-arm-none-eabi-8-2019-q3-update/bin/
+source ${CARGO_HOME}/env
 
 cd /solo/targets/stm32l432
 ls
 
 make cbor
+make salty
 
 out_dir="/builds"
 

--- a/targets/stm32l432/Makefile
+++ b/targets/stm32l432/Makefile
@@ -8,7 +8,7 @@ BOOTMAKE=build/bootloader.mk VERSION_FULL=${VERSION_FULL}
 
 merge_hex=solo mergehex
 
-.PHONY: all all-hacker all-locked debugboot-app debugboot-boot boot-sig-checking boot-no-sig build-release-locked build-release build-release build-hacker build-debugboot clean clean2 flash flash_dfu flashboot detach cbor test
+.PHONY: all all-hacker all-locked debugboot-app debugboot-boot boot-sig-checking boot-no-sig build-release-locked build-release build-release build-hacker build-debugboot clean clean2 flash flash_dfu flashboot detach cbor salty test
 
 
 # The following are the main targets for reproducible builds.
@@ -55,13 +55,13 @@ boot-sig-checking:
 boot-no-sig:
 	$(MAKE) -f $(BOOTMAKE) -j8 bootloader.hex PREFIX=$(PREFIX) EXTRA_DEFINES='-DSOLO_HACKER' DEBUG=0
 
-build-release-locked: cbor clean2 boot-sig-checking clean all-locked
+build-release-locked: salty cbor clean2 boot-sig-checking clean all-locked
 	$(VENV) $(merge_hex) solo.hex bootloader.hex all.hex
 
-build-release: cbor clean2 boot-sig-checking clean all
+build-release: salty cbor clean2 boot-sig-checking clean all
 	$(VENV) $(merge_hex) solo.hex bootloader.hex all.hex
 
-build-hacker: cbor clean2 boot-no-sig clean all-hacker
+build-hacker: salty cbor clean2 boot-no-sig clean all-hacker
 	$(VENV) $(merge_hex) solo.hex bootloader.hex all.hex
 
 build-debugboot: clean2 debugboot-boot clean debugboot-app
@@ -106,6 +106,9 @@ solo.hex:
 
 cbor:
 	$(MAKE) -f $(APPMAKE) -j8 cbor
+
+salty:
+	$(MAKE) -f $(APPMAKE) -j8 salty
 
 test:
 	$(MAKE) build-release-locked

--- a/targets/stm32l432/build/application.mk
+++ b/targets/stm32l432/build/application.mk
@@ -24,12 +24,13 @@ OBJ=$(OBJ1:.s=.o)
 
 INC = -Isrc/ -Isrc/cmsis/ -Ilib/ -Ilib/usbd/
 
-INC+= -I../../fido2/ -I../../fido2/extensions
+INC += -I../../fido2/ -I../../fido2/extensions
 INC += -I../../tinycbor/src -I../../crypto/sha256 -I../../crypto/micro-ecc
 INC += -I../../crypto/tiny-AES-c
 INC += -I../../crypto/cifra/src -I../../crypto/cifra/src/ext
+INC += -I../../crypto/salty/c-api
 
-SEARCH=-L../../tinycbor/lib
+SEARCH=-L../../tinycbor/lib -L../../crypto/salty/c-api
 
 ifndef LDSCRIPT
 LDSCRIPT=linker/stm32l4xx.ld
@@ -52,7 +53,7 @@ DEFINES = -DDEBUG_LEVEL=$(DEBUG) -D$(CHIP) -DAES256=1  -DUSE_FULL_LL_DRIVER -DAP
 CFLAGS=$(INC) -c $(DEFINES)   -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers -fdata-sections -ffunction-sections \
 	-fomit-frame-pointer $(HW) -g $(VERSION_FLAGS)
 LDFLAGS_LIB=$(HW) $(SEARCH) -specs=nano.specs  -specs=nosys.specs  -Wl,--gc-sections -lnosys
-LDFLAGS=$(HW) $(LDFLAGS_LIB) -T$(LDSCRIPT) -Wl,-Map=$(TARGET).map,--cref -Wl,-Bstatic -ltinycbor
+LDFLAGS=$(HW) $(LDFLAGS_LIB) -T$(LDSCRIPT) -Wl,-Map=$(TARGET).map,--cref -Wl,-Bstatic -ltinycbor -lsalty
 
 ECC_CFLAGS = $(CFLAGS) -DuECC_PLATFORM=5 -DuECC_OPTIMIZATION_LEVEL=4 -DuECC_SQUARE_FUNC=1 -DuECC_SUPPORT_COMPRESSED_POINT=0
 

--- a/targets/stm32l432/build/application.mk
+++ b/targets/stm32l432/build/application.mk
@@ -86,3 +86,6 @@ cbor:
 LDFLAGS="$(LDFLAGS_LIB)" \
 CFLAGS="$(CFLAGS) -Os  -DCBOR_PARSER_MAX_RECURSIONS=3"
 
+salty:
+	cd ../../crypto/salty/c-api && cargo clean
+	cd ../../crypto/salty/c-api && $(MAKE)

--- a/targets/stm32l432/build/bootloader.mk
+++ b/targets/stm32l432/build/bootloader.mk
@@ -25,6 +25,7 @@ INC = -Ibootloader/ -Isrc/ -Isrc/cmsis/ -Ilib/ -Ilib/usbd/ -I../../fido2/ -I../.
 INC += -I../../tinycbor/src -I../../crypto/sha256 -I../../crypto/micro-ecc
 INC += -I../../crypto/tiny-AES-c
 INC += -I../../crypto/cifra/src -I../../crypto/cifra/src/ext
+INC += -I../../crypto/salty/c-api
 
 ifndef LDSCRIPT
 LDSCRIPT=linker/bootloader_stm32l4xx.ld


### PR DESCRIPTION
For now:

- libsodium(-dev) is expected to be preinstalled on build system for PC
build

- salty needs to be prebuilt and installed into targets/stm32l432/salty/
manually

They key type is stored in the 'masked metadata' area of the key ID.

The auth buffers have been enlarged by 32 bytes to be able to append the client hash before ED25519 signature generation instead of creating a full message copy.

I have tested this successfully using fido2-tools and ssh-keygen/ssh on both PC and Solo Hacker.

All feedback much appreciated!