### PR TITLE
PC: make build using gcc 10 work.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ endif
 LDFLAGS += $(LIBSOLO) $(LIBCBOR)
 
 
-CFLAGS = -O2 -fdata-sections -ffunction-sections -g
+CFLAGS = -O2 -fdata-sections -ffunction-sections -fcommon -g
 ECC_CFLAGS = -O2 -fdata-sections -ffunction-sections -DuECC_PLATFORM=$(ecc_platform)
 
 INCLUDES =  -I../ -I./fido2/ -I./pc -I../pc -I./tinycbor/src


### PR DESCRIPTION
- declare firmware_version extern in fido2/version.h

- declare RK_STORE 'weak' in fido2/device.c, like the functions
  operating on it

Tested on Ubuntu 20.10 using gcc-9 and gcc-10.