### PR TITLE
Fixing counter increment in ctap_filter_invalid_credentials()

### DIFF
--- a/fido2/ctap.c
+++ b/fido2/ctap.c
@@ -1187,7 +1187,7 @@ int ctap_filter_invalid_credentials(CTAP_getAssertion * GA)
                     break;
                 }
                 GA->creds[count].type = PUB_KEY_CRED_PUB_KEY;
-                memmove(&(GA->creds[count].credential), &rk, sizeof(CTAP_residentKey));
+                memmove(&(GA->creds[count].credential), &rk, sizeof(struct Credential));
                 count++;
             }
         }

--- a/fido2/ctap.c
+++ b/fido2/ctap.c
@@ -1181,7 +1181,7 @@ int ctap_filter_invalid_credentials(CTAP_getAssertion * GA)
             if (memcmp(rk.id.rpIdHash, rpIdHash, 32) == 0)
             {
                 printf1(TAG_GA, "RK %d is a rpId match!\r\n", i);
-                if (count == ALLOW_LIST_MAX_SIZE-1)
+                if (count >= ALLOW_LIST_MAX_SIZE)
                 {
                     printf2(TAG_ERR, "not enough ram allocated for matching RK's (%d).  Skipping.\r\n", count);
                     break;


### PR DESCRIPTION
This change fixes some issues with the [fido2-tests](https://github.com/solokeys/fido2-tests). Specifically it fixes:

- [This line](https://github.com/solokeys/fido2-tests/blob/9561b5b50279c2e71db37aedd241b029627b38b1/tests/standard/fido2/test_resident_key.py#L221). Now Solo returns the correct number of credentials allowing one more test to succeed.
- [These lines](https://github.com/solokeys/fido2-tests/blob/9561b5b50279c2e71db37aedd241b029627b38b1/tests/standard/fido2/test_resident_key.py#L238-L240) since `getAssertionState.user_verified` is no longer mistakenly set to 0 due to a wrong size used during the memmove().
- [These lines](https://github.com/solokeys/fido2-tests/blob/9561b5b50279c2e71db37aedd241b029627b38b1/tests/standard/fido2/test_resident_key.py#L170-L172) for same reason above.

Notice that the tests still fail due to design choices (["Initial SoloKeys model truncates displayName"](https://github.com/solokeys/fido2-tests/blob/9561b5b50279c2e71db37aedd241b029627b38b1/tests/standard/fido2/test_resident_key.py#L190)).

I'm currently testing the PC (UDP) version without hardware needed (version 4.0.0).