### PR TITLE
Added ARM compiler Path to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ RUN set -eux; \
 	echo "b50b02b0a16e5aad8620e9d7c31110ef285c1dde28980b1a9448b764d77d8f92 gcc.tar.bz2" | sha256sum -c -; \
 	tar -C /opt -xf gcc.tar.bz2; \
 	rm gcc.tar.bz2;
+# Set Path for ARM compiler
+ENV PATH="$PATH:/opt/gcc-arm-none-eabi-8-2019-q3-update/bin"
 
 # Python3.7: for solo-python (merging etc.)
 RUN set -eux; \


### PR DESCRIPTION
Added the ARM compiler Path variable to the Dockerfile. Thisway the arm-none-eabi-gcc can be called from withing the solo make file. Furthermore enables the user to use the ARM compiler without knowing the PATH.