### PR TITLE
docs: Remove obsolete flags from solo key update

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,7 +11,7 @@ To update your key:
 - either visit <https://update.solokeys.com>, or
 - use our commandline tool <https://github.com/solokeys/solo-python>:
 ```
-solo key update [--secure|--hacker]
+solo key update
 ```
 
 ## Reporting a Vulnerability

--- a/docs/programming.md
+++ b/docs/programming.md
@@ -12,11 +12,10 @@ pip3 install solo-python
 
 ## Updating the firmware
 
-If you just want to update the firmware, you can run one of the following commands.
-Make sure your key [is in bootloader mode](/bootloader-mode#solo-bootloader) first.
+If you just want to update the firmware, you can run:
 
 ```bash
-solo key update <--secure | --hacker>
+solo key update
 ```
 
 You can manually install the [latest release](https://github.com/solokeys/solo/releases), or use a build that you made.

--- a/docs/tutorial-getting-started.md
+++ b/docs/tutorial-getting-started.md
@@ -134,7 +134,7 @@ solo key version
 To update to the newest version, use this command:
 
 ```bash
-solo key version
+solo key update
 ```
 
 **Note:** Sometimes the connection between Mac and key seemed to be broken and you might get an error stating: _No solo found_. Just unplug the key and plug it back in.
@@ -211,7 +211,7 @@ make build-hacker
 #Change to root
 cd ../..
 
-#Enter bootload mode
+#Enter bootloader mode
 solo program aux enter-bootloader
 
 #Deploy code


### PR DESCRIPTION
Hello, this PR will remove the obsolete `--hacker|--secure` arguments from `solo key update` and some unneeded commands since the latest solo python version makes sure the key is in bootloader mode. Also, fixes some typos.