### PR TITLE
Fix compilation warnings

### DIFF
--- a/fido2/ctap_parse.c
+++ b/fido2/ctap_parse.c
@@ -1064,7 +1064,7 @@ static uint8_t parse_cred_mgmt_subcommandparams(CborValue * val, CTAP_credMgmt *
 
     const uint8_t * end_byte = cbor_value_get_next_byte(&map);
 
-    uint32_t length = (uint32_t)end_byte - (uint32_t)start_byte;
+    uint32_t length = (uint32_t)(end_byte - start_byte);
     if (length > sizeof(CM->hashed.subCommandParamsCborCopy))
     {
         return CTAP2_ERR_LIMIT_EXCEEDED;

--- a/pc/device.c
+++ b/pc/device.c
@@ -15,6 +15,7 @@
 #include <unistd.h>
 #include <signal.h>
 #include <fcntl.h>
+#include <time.h>
 
 #include "device.h"
 #include "cbor.h"


### PR DESCRIPTION
The call to `nanosleep` was missing it's header and the `length` calculation in `parse_cred_mgmt_subcommandparams` could be wrong when compiled for 64-bit targets. Both of these showed up as compiler warnings.

I'm no C developer, but I believe these changes are correct fixes.

Edit: These were the only warnings that showed up when running `make all` on Fedora 33.