### PR TITLE
Support stdin/stdout transport for USB HID messages for PC target

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ cd solo
 make all
 ```
 
-This builds Solo as a standalone application. Solo application is set up to send and recv USB HID messages over UDP to ease development and reduce need for hardware.
+This builds Solo as a standalone application. Solo application is set up to send and recv USB HID messages over UDP or stdin/stdout to ease development and reduce need for hardware.
 
 Testing can be done using our fork of Yubico's client software, python-fido2. Our fork of python-fido2 has small changes to make it send USB HID over UDP to the authenticator application. You can install our fork by running the following:
 

--- a/fido2/log.c
+++ b/fido2/log.c
@@ -72,7 +72,7 @@ void LOG(uint32_t tag, const char * filename, int num, const char * fmt, ...)
     {
         if (tag & tagtable[i].tagn)
         {
-            if (tagtable[i].tag[0] && !(tag & TAG_NO_TAG)) printf("[%s] ", tagtable[i].tag);
+            if (tagtable[i].tag[0] && !(tag & TAG_NO_TAG)) fprintf(stderr, "[%s] ", tagtable[i].tag);
             i = 0;
             break;
         }
@@ -86,12 +86,12 @@ void LOG(uint32_t tag, const char * filename, int num, const char * fmt, ...)
 #ifdef ENABLE_FILE_LOGGING
     if (tag & TAG_FILENO)
     {
-        printf("%s:%d: ", filename, num);
+        fprintf(stderr, "%s:%d: ", filename, num);
     }
 #endif
     va_list args;
     va_start(args, fmt);
-    vprintf(fmt, args);
+    vfprintf(stderr, fmt, args);
     va_end(args);
 }
 

--- a/fido2/util.c
+++ b/fido2/util.c
@@ -11,7 +11,7 @@ void dump_hex(uint8_t * buf, int size)
 {
     while(size--)
     {
-        printf("%02x ", *buf++);
+        fprintf(stderr, "%02x ", *buf++);
     }
-    printf("\n");
+    fprintf(stderr, "\n");
 }

--- a/pc/app.h
+++ b/pc/app.h
@@ -21,7 +21,6 @@
 
 void printing_init();
 
-extern bool use_udp;
 
 //                              0xRRGGBB
 #define LED_INIT_VALUE			0x000800


### PR DESCRIPTION
This allows the PC development target to use stdin/stdout for transporting USB HID messages. It can be useful as it doesn't requiring using fixed UDP ports that would otherwise prevent concurrent use.

There is no framing or similar added, USB HID report messages are read directly from stdin and written directly to stdout. Each message will be `HID_MESSAGE_SIZE` (64) bytes long.

Any `printf` calls that would write to stdout are changed to write instead to stderr. This is more appropriate and consistent anyway.

---

I've been using this to test a FIDO2/CTAP client I've been working on and it's proven really useful. In my particular usage having to connect via UDP is a lot more awkward than being able to use stdin and stdout.

I modelled this on the HID gadget implementation, this has the potential downside that `read` blocks (I presume it blocks for HID gadget too). This doesn't seem to cause any problems from what I can tell, though I suppose something like  `udp_recv` could be used to do a non-blocking read.

I'm no C developer, but I believe this change is correct.

I know the Solo v2 firmware is in development, but I do think that this is still useful to provide multiple targets to test against.