### PR TITLE
Fixed crash on assert in parse_cred_mgmt_subcommandparams()

### DIFF
--- a/fido2/ctap_parse.c
+++ b/fido2/ctap_parse.c
@@ -1046,6 +1046,11 @@ static uint8_t parse_cred_mgmt_subcommandparams(CborValue * val, CTAP_credMgmt *
         switch(key)
         {
             case CM_subCommandRpId:
+                if (cbor_value_get_type(&map) != CborByteStringType)
+                {
+                    printf2(TAG_ERR,"Error, expecting byte-string type for sub-command RpId map value, got %s\n", cbor_value_get_type_string(&map));
+                    return CTAP2_ERR_INVALID_CBOR_TYPE;
+                }
                 ret = cbor_value_copy_byte_string(&map, CM->subCommandParams.rpIdHash, &sz, NULL);
                 if (ret == CborErrorOutOfMemory)
                 {


### PR DESCRIPTION
There was no check that the map value was actually a byte string, this makes it
possible to pass invalid input into cbor_value_copy_byte_string() function from
tinycbor. There is an assertion to check the type of the input, and it is possible
to make it fail.

Here is an example payload that would make the assertion fail:

 \x41\x41\x41\x41\x90\x00\x10\x41\xa1\x02\xa1\x01\x62\x58\x58

Payload structure explenation:
  * CID: "AAAA"
  * CMD: CTAPHID_CBOR (0x90)
  * BCNT: 16
  * SUBCMD: CTAP_CBOR_CRED_MGMT_PRE (0x41)
     * MAP {
        * CM_subCommandParams MAP {
           * CM_subCommandRpId = "XX"     // <== regular string, not byte string
        }
     }