### PR TITLE
Fix parsing errors in `ctap_parse_hmac_secret`

### DIFF
--- a/fido2/ctap_parse.c
+++ b/fido2/ctap_parse.c
@@ -621,8 +621,16 @@ uint8_t ctap_parse_hmac_secret(CborValue * val, CTAP_hmac_secret * hs)
             case EXT_HMAC_SECRET_SALT_AUTH:
                 ++salt_auth_parsed;
                 salt_len = 32;
-                ret = cbor_value_copy_byte_string(&map, hs->saltAuth, &salt_len, NULL);
-                check_ret(ret);
+                if (cbor_value_get_type(&map) == CborByteStringType)
+                {
+                    ret = cbor_value_copy_byte_string(&map, hs->saltAuth, &salt_len, NULL);
+                    check_ret(ret);
+                }
+                else
+                {
+                    printf2(TAG_ERR, "error, CborByteStringType expected\r\n");
+                    return CTAP2_ERR_INVALID_CBOR_TYPE;
+                }
             break;
         }
 


### PR DESCRIPTION
1. **`saltEnc` type was not checked causing an assertion in `cbor_value_copy_byte_string` to fail.**
Reproduce using solo-python: Go to `HmacSecretExtension` in `extensions.py` in python-fido2 and replace `2: salt_enc` by `2: "hey"`, run `solo key challenge-response`.

2. **Parameters could be omitted by duplicating known keys, causing parsed_count to increase anyway.** This causes reading later on of arrays that are still 0.
Reproduce using solo-python: Go to `HmacSecretExtension` in `extensions.py` in python-fido2 and replace `1: key_agreement` by `-42: True`, then go to `dump_dict` in `cbor.py` in python-fido2 and replace it by:
```python3
def dump_dict(data):
    items = [(encode(k), encode(v)) for k, v in data.items() if k != -42]
    if -42 in data:
        items.append((encode(2), encode(data[2])))
    items.sort(key=_sort_keys)
    return dump_int(len(items), mt=5) + b"".join([k + v for (k, v) in items])
```
and run `solo key challenge-response`.
This will duplicate `saltEnc(2)` while removing `keyAgreement(1)`, so the total number of keys will remain 3, which `ctap_parse_hmac_secret` will happily accept. You can also choose other parameters to duplicate. We cannot directly add a duplicate key to the `dict` because Python will ignore it.

Is there maybe somewhere that regression tests for this can be added? Maybe I could add something to solokeys/fido2-tests, if that's the right place for this.