### PR TITLE
works out-of-box on Debian 11

### DIFF
--- a/docs/udev.md
+++ b/docs/udev.md
@@ -4,7 +4,7 @@ On Linux, by default USB dongles can't be accessed by users, for security reason
 
 For some users, things will work automatically:
 
-  - Recent Linux distributions (such as Ubuntu Focal, Fedora 32, [Arch Linux](https://wiki.archlinux.org/index.php/Solo)) with systemd 244 or higher automatically detect FIDO devices (check with `systemctl --version`)
+  - Recent Linux distributions (such as Debian 11, Ubuntu Focal, Fedora 32, [Arch Linux](https://wiki.archlinux.org/index.php/Solo)) with systemd 244 or higher automatically detect FIDO devices (check with `systemctl --version`)
   - Fedora seems to use a ["universal" udev rule for FIDO devices](https://github.com/amluto/u2f-hidraw-policy)
   - Our udev rule made it into [libu2f-host](https://github.com/Yubico/libu2f-host/) v1.1.10
   - [Debian Buster](https://packages.ubuntu.com/buster/libu2f-udev) and [Ubuntu Groovy](https://packages.ubuntu.com/groovy/libu2f-udev) can use the `libu2f-udev` package


### PR DESCRIPTION
I just received my solokey V2, plugged it into my machine running Debian 11 (bullseye), and i successfully was able to set it up with google, github... 
I'm using:
Mozilla Firefox 78.15.0esr
systemd 247 (247.3-6)