### PR TITLE
pc/device.c: remove unused argument to ctap_init()

### DIFF
--- a/pc/device.c
+++ b/pc/device.c
@@ -253,7 +253,7 @@ void device_init(int argc, char *argv[])
 
     ctaphid_init();
 
-    ctap_init( 1 );
+    ctap_init();
 }
 
 


### PR DESCRIPTION
`ctap_init` doesn't take an argument. It hasn't taken an argument since 2019 (e8d0ad5e7cf2f8bd5a57aae8e5e8b69d3816474c).

But due to a quirk of C that was [finally removed in C23](https://www.open-std.org/jtc1/sc22/wg14/www/docs/n2841.htm), passing it an argument was valid. Now it isn't, and this project no longer builds, so this PR removes the bit that makes it not build.